### PR TITLE
remove NLU api to call function directly

### DIFF
--- a/create.py
+++ b/create.py
@@ -20,9 +20,9 @@ from arklex.utils.model_config import MODEL
 logger = init_logger(log_level=logging.INFO, filename=os.path.join(os.path.dirname(__file__), "logs", "arklex.log"))
 load_dotenv()
 
-API_PORT = "55135"
-NLUAPI_ADDR = f"http://localhost:{API_PORT}/nlu"
-SLOTFILLAPI_ADDR = f"http://localhost:{API_PORT}/slotfill"
+# API_PORT = "55135"
+# NLUAPI_ADDR = f"http://localhost:{API_PORT}/nlu"
+# SLOTFILLAPI_ADDR = f"http://localhost:{API_PORT}/slotfill"
 
 def generate_taskgraph(args):
     model = ChatOpenAI(model=MODEL["model_type_or_path"], timeout=30000)
@@ -30,8 +30,8 @@ def generate_taskgraph(args):
     taskgraph_filepath = generator.generate()
     # Update the task graph with the API URLs
     task_graph = json.load(open(os.path.join(os.path.dirname(__file__), taskgraph_filepath)))
-    task_graph["nluapi"] = NLUAPI_ADDR
-    task_graph["slotfillapi"] = SLOTFILLAPI_ADDR
+    task_graph["nluapi"] = ""
+    task_graph["slotfillapi"] = ""
     with open(taskgraph_filepath, "w") as f:
         json.dump(task_graph, f, indent=4)
 
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     parser.add_argument('--output-dir', type=str, default="./examples/test")
     parser.add_argument('--model', type=str, default=MODEL["model_type_or_path"])
     parser.add_argument('--log-level', type=str, default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
-    parser.add_argument('--task', type=str, choices=["gen_taskgraph", "init", "all"], default="gen_taskgraph")
+    parser.add_argument('--task', type=str, choices=["gen_taskgraph", "init", "all"], default="all")
     args = parser.parse_args()
     MODEL["model_type_or_path"] = args.model
     log_level = getattr(logging, args.log_level.upper(), logging.INFO)

--- a/examples/customer_service/taskgraph.json
+++ b/examples/customer_service/taskgraph.json
@@ -872,6 +872,6 @@
         }
     ],
     "tools": [],
-    "nluapi": "http://localhost:55135/nlu",
-    "slotfillapi": "http://localhost:55135/slotfill"
+    "nluapi": "",
+    "slotfillapi": ""
 }

--- a/examples/shopify/taskgraph.json
+++ b/examples/shopify/taskgraph.json
@@ -150,6 +150,6 @@
         {"id": "26bb6634-3bee-417d-ad75-23269ac17bc3", "name": "MessageWorker","path": "message_worker.py"},
         {"id": "40f05456-525c-4d9d-ac37-54482d6b220b", "name": "FaissRAGWorker", "path": "faiss_rag_worker.py"}
     ],
-    "nluapi": "http://localhost:55135/nlu",
-    "slotfillapi": "http://localhost:55135/slotfill"
+    "nluapi": "",
+    "slotfillapi": ""
 }

--- a/run.py
+++ b/run.py
@@ -18,7 +18,6 @@ from arklex.orchestrator.orchestrator import AgentOrg
 from arklex.utils.model_config import MODEL
 from arklex.env.env import Env
 
-API_PORT = "55135"
 load_dotenv()
 # session = shopify.Session(os.environ["SHOPIFY_SHOP_URL"], os.environ["SHOPIFY_API_VERSION"], os.environ["SHOPIFY_ACCESS_TOKEN"])
 # shopify.ShopifyResource.activate_session(session)
@@ -90,7 +89,7 @@ if __name__ == "__main__":
     logger = init_logger(log_level=log_level, filename=os.path.join(os.path.dirname(__file__), "logs", "arklex.log"))
 
     # Initialize NLU and Slotfill APIs
-    start_apis()
+    # start_apis()
 
     # Initialize env
     config = json.load(open(os.path.join(args.input_dir, "taskgraph.json")))


### PR DESCRIPTION
NLU automate api start/terminate failed so that user intent detection failed, lead to "others" intent which will be hard for debugging unless open Logger Info. 
The current fix is using function calling instead of API calling to do the NLU.