### PR TITLE
Append metadata to tau_bench_evaluation result

### DIFF
--- a/arklex/orchestrator/orchestrator.py
+++ b/arklex/orchestrator/orchestrator.py
@@ -248,13 +248,13 @@ class AgentOrg:
                     node_actions = [{"name": self.env.id2name[node_info["id"]], "description": self.env.workers[node_info["id"]]["execute"]().description}]
                 
                 # If the Default Worker enters the loop, it is the default node. It may call the RAG worker and no information in the context (tool response) can be used.
-                if node_info["id"] == self.env.name2id["DefaultWorker"]:
+                if "DefaultWorker" in self.env.name2id.keys() and node_info["id"] == self.env.name2id["DefaultWorker"]:
                     logger.info("Skip the DefaultWorker in ReAct framework because it is the default node and may call the RAG worker (context cannot be used)")
                     action = RESPOND_ACTION_NAME
                     FINISH = True
                     break
                 # If the Message Worker enters the loop, ReAct framework cannot make a good decision between the MessageWorker and the RESPOND action.
-                elif node_info["id"] == self.env.name2id["MessageWorker"]:
+                elif "MessageWorker" in self.env.name2id.keys() and node_info["id"] == self.env.name2id["MessageWorker"]:
                     logger.info("Skip ReAct framework because it is hard to distinguish between the MessageWorker and the RESPOND action")
                     message_state["response"] = "" # clear the response cache generated from the previous steps in the same turn
                     message_state["metadata"] = {"chat_id": metadata.get("chat_id"), "turn_id": metadata.get("turn_id"), "tool_response": []}

--- a/benchmark/tau_bench/agents/agent_first_org.py
+++ b/benchmark/tau_bench/agents/agent_first_org.py
@@ -63,7 +63,11 @@ class AgentFirstOrg(Agent):
             output, params = self.get_api_bot_response(deepcopy(history), user_text, params)
 
             user_message = {"role": "user", "content": user_text}
-            assistant_message = {"role": "assistant", "content": output}
+            assistant_message = {"role": "assistant", "content": output, 
+                                 'curr_node': params['curr_node'],
+                                 'intent': params['nlu_records'][-1]['pred_intent'],
+                                 'metadata': params['metadata'],
+                                 'node_status': params['node_status']}
             history.append(user_message)
             history.append(assistant_message)
 

--- a/benchmark/tau_bench/tau_bench_eval.py
+++ b/benchmark/tau_bench/tau_bench_eval.py
@@ -69,7 +69,7 @@ class TauBenchResourceInitializer(DefaulResourceInitializer):
             tool_output = []
             isComplete = lambda x: True
             
-            tool = tool_lambda(Tool(tool_func, tool_key, tool_desc, tool_slots, tool_output, isComplete))
+            tool = tool_lambda(Tool(tool_func, tool_key, tool_desc, tool_slots, tool_output, isComplete, isResponse=False))
 
             tool_registry[tool_id] = {
                 "name": tool_name,
@@ -166,7 +166,13 @@ if __name__ == "__main__":
     parser.add_argument('--output-dir', type=str, default="./examples/tau_bench")
     parser.add_argument('--num-trials', type=int, default=1)
     parser.add_argument('--env', type=str, default="retail", choices=["retail"])
-    parser.add_argument('--task-ids', type=list, default=[1,2,3,4,5,6,7,8,9,10])
+
+    import random
+    random.seed(42)
+    random_list = random.sample(range(118), 10)
+    print(f"Running Tau Bench on tasks {random_list}")
+    parser.add_argument('--task-ids', type=list, default=random_list)
+    # parser.add_argument('--task-ids', type=list, default=[1,2,3,4,5,6,7,8,9,10])
 
     parser.add_argument('--model_api', type=str, default="http://127.0.0.1:8000/eval/chat")
     parser.add_argument('--model', type=str, default=MODEL["model_type_or_path"])


### PR DESCRIPTION
This PR includes the following changes:

- Fix: `arklex/orchestrator/orchestrator.py` Updated  to fix key error issues when indexing DefaultWorker and MessageWorker. 
- Fix: `benchmark/tau_bench/tau_bench_eval.py` Randomize default task selection in tau bench evaluation.
- Feature: `benchmark/tau_bench/agents/agent_first_org.py` Append metadata to tau_bench evaluation result.
