### PR TITLE
Fix/taskgraph

### DIFF
--- a/arklex/orchestrator/task_graph.py
+++ b/arklex/orchestrator/task_graph.py
@@ -238,13 +238,12 @@ class TaskGraph(TaskGraphBase):
                 available_intents[self.unsure_intent.get("intent")].append(self.unsure_intent)
         logger.info(f"available_intents: {available_intents}")
         
-        if not params.get("available_nodes", None):
-            available_nodes = {}
-            for node in self.graph.nodes.data():
-                available_nodes[node[0]] = {"limit": node[1]["limit"]}
-            params["available_nodes"] = available_nodes
-        else:
-            available_nodes = params.get("available_nodes")
+        # Re-initialize available_nodes to deal with the case that the taskgraph is updated during the conversation
+        available_nodes = {}
+        for node in self.graph.nodes.data():
+            available_nodes[node[0]] = {"limit": node[1]["limit"]}
+        params["available_nodes"] = available_nodes
+        logger.info(f"available_nodes: {available_nodes}")
         
         if not list(self.graph.successors(curr_node)):  # leaf node
             if flow_stack:  # there is previous unfinished flow

--- a/arklex/orchestrator/task_graph.py
+++ b/arklex/orchestrator/task_graph.py
@@ -217,6 +217,7 @@ class TaskGraph(TaskGraphBase):
         if not curr_node or curr_node not in self.graph.nodes:
             curr_node = self.start_node
             params["curr_node"] = curr_node
+            params["curr_pred_intent"] = None
         else:
             curr_node = str(curr_node)
         logger.info(f"Intial curr_node: {curr_node}")
@@ -238,11 +239,24 @@ class TaskGraph(TaskGraphBase):
                 available_intents[self.unsure_intent.get("intent")].append(self.unsure_intent)
         logger.info(f"available_intents: {available_intents}")
         
-        # Re-initialize available_nodes to deal with the case that the taskgraph is updated during the conversation
-        available_nodes = {}
-        for node in self.graph.nodes.data():
-            available_nodes[node[0]] = {"limit": node[1]["limit"]}
-        params["available_nodes"] = available_nodes
+        if not params.get("available_nodes", None):
+            available_nodes = {}
+            for node in self.graph.nodes.data():
+                available_nodes[node[0]] = {"limit": node[1]["limit"]}
+            params["available_nodes"] = available_nodes
+        else:
+            # Re-initialize available_nodes to deal with the case that the taskgraph is updated during the conversation
+            old_available_nodes = params.get("available_nodes")
+            available_nodes = {}
+            # node is not in the current graph, remove it from available_modes
+            for node in old_available_nodes.keys():
+                if node in self.graph.nodes:
+                    available_nodes[node] = {"limit": old_available_nodes[node]["limit"]}
+            # add the new nodes to available_nodes
+            for node in self.graph.nodes.data():
+                if node[0] not in available_nodes.keys():
+                    available_nodes[node[0]] = {"limit": node[1]["limit"]}
+            params["available_nodes"] = available_nodes
         logger.info(f"available_nodes: {available_nodes}")
         
         if not list(self.graph.successors(curr_node)):  # leaf node

--- a/arklex/utils/graph_state.py
+++ b/arklex/utils/graph_state.py
@@ -10,7 +10,7 @@ class BotConfig(BaseModel):
     version: str
     language: str
     bot_type: str
-    available_workers: list[dict[str, str]]
+    available_workers: list[dict[str, Optional[str]]]
 
 
 ### Message-related classes


### PR DESCRIPTION
There was a problem with the taskgraph update during conversation.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4d20c45d-d125-4bac-9115-a8432256e55e" />
If the taskgraph traverses to a node, and the taskgraph is updated during the conversation (a new edge is linked to the node), `available_nodes` is from the last round and do not include the new node id, which causes an error.
