### PR TITLE
Taskgraph generation with Gemini/Anthropic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ python create.py --config ./examples/customer_service_config.json --output-dir .
 * Fields:
   * `--config`: The path to the config file
   * `--output-dir`: The directory to save the generated files
-  * `--model`: The openai model type used to generate the taskgraph. The default is `gpt-4o`. You could change it to other models like `gpt-4o-mini`.
+  * `--llm_provider`: The LLM provider you wish to use. 
+    - Options: `openai` (default), `gemini`, `anthropic`
+  *  `--model`: The model type used to generate the taskgraph. The default is `gpt-4o`. 
+      - You can change this to other models like:
+        - `gpt-4o-mini`
+        - `gemini-2.0-flash`
+        - `claude-3-5-haiku-20241022`
 
 * It will first generate a task plan based on the config file and you could modify it in an interactive way from the command line. Made the necessary changes and press `s` to save the task plan under `output-dir` folder and continue the task graph generation process.
 * Then it will generate the task graph based on the task plan and save it under `output-dir` folder as well.
@@ -77,11 +83,11 @@ python run.py --input-dir ./examples/customer_service
   * `--input-dir`: The directory that contains the generated files
   * `--llm_provider`: The LLM provider you wish to use. 
     - Options: `openai` (default), `gemini`, `anthropic`
-  * `--model`: The model type used to generate bot response. Default is `gpt-4o`. 
+  * `--model`: The model type used to generate bot response. The default is `gpt-4o`. 
     - You can change this to other models like:
       - `gpt-4o-mini`
-      - `gemini-2.0-flash-exp`
-      - `claude-3-haiku-20240307`
+      - `gemini-2.0-flash`
+      - `claude-3-5-haiku-20241022`
   
 
 * It will first automatically start the nluapi and slotapi services through `start_apis()` function. By default, this will start the `NLUModelAPI ` and `SlotFillModelAPI` services defined under `./arklex/orchestrator/NLU/api.py` file. You could customize the function based on the nlu and slot models you trained.

--- a/arklex/utils/model_provider_config.py
+++ b/arklex/utils/model_provider_config.py
@@ -31,7 +31,7 @@ PROVIDER_EMBEDDINGS = {
     "huggingface": HuggingFaceEmbeddings
 }
 PROVIDER_EMBEDDING_MODELS = {
-    "anthropic": "sentence-transformers/all-mpnet-base-v2",
+    "anthropic": "sentence-transformers/sentence-t5-base",
     "gemini": "models/embedding-001",
     "openai": "text-embedding-ada-002",
     "huggingface": "sentence-transformers/all-mpnet-base-v2",

--- a/create.py
+++ b/create.py
@@ -16,6 +16,7 @@ from arklex.orchestrator.generator.generator import Generator
 from arklex.env.tools.RAG.build_rag import build_rag
 from arklex.env.tools.database.build_database import build_database
 from arklex.utils.model_config import MODEL
+from arklex.utils.model_provider_config import LLM_PROVIDERS, PROVIDER_MAP
 
 logger = init_logger(log_level=logging.INFO, filename=os.path.join(os.path.dirname(__file__), "logs", "arklex.log"))
 load_dotenv()
@@ -25,7 +26,7 @@ load_dotenv()
 # SLOTFILLAPI_ADDR = f"http://localhost:{API_PORT}/slotfill"
 
 def generate_taskgraph(args):
-    model = ChatOpenAI(model=MODEL["model_type_or_path"], timeout=30000)
+    model = PROVIDER_MAP.get(MODEL['llm_provider'], ChatOpenAI)(model=MODEL["model_type_or_path"],timeout=30000)
     generator = Generator(args, args.config, model, args.output_dir)
     taskgraph_filepath = generator.generate()
     # Update the task graph with the API URLs
@@ -69,10 +70,12 @@ if __name__ == "__main__":
     parser.add_argument('--config', type=str, default="./arklex/orchestrator/examples/customer_service_config.json")
     parser.add_argument('--output-dir', type=str, default="./examples/test")
     parser.add_argument('--model', type=str, default=MODEL["model_type_or_path"])
+    parser.add_argument( '--llm-provider',type=str,default=MODEL["llm_provider"],choices=LLM_PROVIDERS)
     parser.add_argument('--log-level', type=str, default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
     parser.add_argument('--task', type=str, choices=["gen_taskgraph", "init", "all"], default="all")
     args = parser.parse_args()
     MODEL["model_type_or_path"] = args.model
+    MODEL["llm_provider"] = args.llm_provider
     log_level = getattr(logging, args.log_level.upper(), logging.INFO)
     logger = init_logger(log_level=log_level, filename=os.path.join(os.path.dirname(__file__), "logs", "arklex.log"))
 

--- a/docs/docs/Config/ChatModels.md
+++ b/docs/docs/Config/ChatModels.md
@@ -2,43 +2,66 @@
 
 ## Supported Language Models
 ### Providers
-**1\. OpenAI** (Default)
-- Models: `gpt-4o` (default), `gpt-4o-mini`
+#### OpenAI (Default)
+- Models: `gpt-4o` (default), `gpt-4o-mini`, `gpt-4.5-preview`
 
-**2\. Google Gemini**
+####  Google Gemini
 - Models: ` gemini-1.5-flash`, `gemini-2.0-flash`, `gemini-2.0-flash-lite`
 
 - **NOTE:** Tool calling is only supported with `gemini-2.0-flash`
 
-**3\. Anthropic**
-- Models: `claude-3-5-haiku-20241022`, `claude-3-haiku-20240307`
+####  Anthropic
+- Models: `claude-3-5-haiku-20241022`, `claude-3-haiku-20240307`, `claude-3-7-sonnet-20250219`
 
-**3\. Hugging Face**
+####  Hugging Face
 - Models: `microsoft/Phi-3-mini-4k-instruct`
 - **NOTE:** Tool calling is NOT supported for Hugging Face
 
-## Taskgraph 
-- **Note:** Taskgraph construction with different models isn't supported at the time, only OpenAI can be used. Feature is planned to be implemented in the future.
+## Taskgraph Generation
+### OpenAI (Default)
+- Add your `OPEN_API_KEY` to the `.env` file
+- Example usage:
+    ```
+    python create.py --config ./examples/customer_service_config.json --output-dir ./examples/customer_service --model gpt-4o-mini --llm-provider openai
+    ```
+
+### Google Gemini
+- Add your `GOOGLE_API_KEY` and `GEMINI_API_KEY` to the `.env` file
+  - Note: Both API keys should be the same
+- Example usage:
+  ```
+  python create.py --config ./examples/customer_service_config.json --output-dir ./examples/customer_service --model gemini-2.0-flash --llm-provider gemini
+    ```
+
+
+### Anthropic
+- Add your `ANTHROPIC_API_KEY` to the `.env` file
+- Example usage:
+  ```
+  python create.py --config ./examples/customer_service_config.json --output-dir ./examples/customer_service --model claude-3-5-haiku-20241022 --llm-provider anthropic
+    ```
+
+### Hugging Face
+- Taskgraph generation is not supported for Hugging Face but will be implemented in the future.
 
 ## Running the Bot
 
-### OpenAI
-- Add your `OPEN_API_KEY` to the `.env` file
+### OpenAI(Default)
+- Ensure your `OPEN_API_KEY` is in the `.env` file
 - Example usage:
     ```
     python run.py --input-dir ./examples/customer_service --model gpt-4o-mini --llm-provider openai
     ```
     
 ### Google Gemini
-- Add your `GOOGLE_API_KEY`  and `GEMINI_API_KEY` to the `.env` file
-    - Note: Both API keys should be the same
+- Ensure your `GOOGLE_API_KEY` and `GEMINI_API_KEY` are in the `.env` file
 - Example usage:
      ```
     python run.py --input-dir ./examples/customer_service --model gemini-2.0-flash-lite --llm-provider gemini
     ```
 
 ### Anthropic
-- Add your `ANTHROPIC_API_KEY` to the `.env` file
+- Ensure your `ANTHROPIC_API_KEY` is in the `.env` file
 - Example usage:
     ```
     python run.py --input-dir ./examples/customer_service --model claude-3-5-haiku-20241022 --llm-provider anthropic


### PR DESCRIPTION
## Summary

Added support for task graph generation with more LLM providers(i.e. Gemini and Anthropic)

- Task: [https://www.notion.so/arklex/Taskgraph-Generation-with-Gemini-Anthropic-1c82ad77209380328245ca694cd44a82](https://www.notion.so/1c82ad77209380328245ca694cd44a82?pvs=21)
- Added to existing documentation(Taskgraph section): [https://www.notion.so/arklex/LLM-Integration-Documentation-1a32ad7720938061b259e44a03ac72ec](https://www.notion.so/1a32ad7720938061b259e44a03ac72ec?pvs=21)

## Description

- Why: Need to make multiple LLM providers compatible with the dev tool. An important & critical step is being able to generate the task graph.
- How: Made updates to the following files:
    - **docs/docs/Config/ChatModels.md**: added documentation for taskgraph generation for Gemini & Anthropic
    - **README.md**: added how to run create.py with Gemini & Anthropic models
    - **create.py:** added new input args(i.e. llm_provider)

## Tests

Test cases involve creating task graph and running chat portion using Anthropic & Gemini models. Also, verifying the updated documentation.

- [ ]  Test case 1: For Anthropic
    - [ ]  `python create.py --config ./examples/customer_service_config.json --output-dir ./examples/customer_service --model claude-3-5-haiku-20241022 --llm-provider anthropic`
    - [ ]  `python run.py --input-dir ./examples/customer_service --model claude-3-5-haiku-20241022 --llm-provider anthropic`
- [ ]  Test case 2: For Gemini
    - [ ]  `python create.py --config ./examples/customer_service_config.json --output-dir ./examples/customer_service --model gemini-2.0-flash --llm-provider gemini`
    - [ ]  `python run.py --input-dir ./examples/customer_service --model gemini-2.0-flash --llm-provider gemini`
- [ ]  Test case 3: Deploy it locally and run the documentation, go to `Config/ChatModels` and look under `Taskgraph Generation`  subsection

## Reviewers

- @xinyang-articulate
- @luyunan0404