### PR TITLE
Add tool's input/output for Incomplete trajectory 

### DIFF
--- a/arklex/env/tools/tools.py
+++ b/arklex/env/tools/tools.py
@@ -151,9 +151,10 @@ class Tool:
                 "name": self.name,
                 "content": response
             })
-            state.trajectory[-1][-1].input = slots
-            state.trajectory[-1][-1].output = response
             state.status = StatusEnum.COMPLETE if tool_success else StatusEnum.INCOMPLETE
+
+        state.trajectory[-1][-1].input = slots
+        state.trajectory[-1][-1].output = response
 
         if self.isResponse and tool_success:
             logger.info("Tool output is stored in response instead of message flow")


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- add tool's input and output even though it doesn't extract all the slots for execution


## Description
<!-- Provide detailed information about the changes -->
- Previously, when the slots of a tool hasn't been extracted completely, the slots and response of the tool won't be added into the trajectory, which causing incomplete information when do the evaluation analysis. 
- Now all the slots and response result will be saved into the trajectory no matter whether successfully execute.


## Tests
<!-- How did you verify these changes? -->
- [X] Test case 1: Run the shopify user simulator evaluation and all the tool's has input and output
![image](https://github.com/user-attachments/assets/4de6fcd1-77c4-4c27-9f59-d613ae9b4d86)


## Reviewers
<!-- Mention the reviewers for this PR -->
- @ryanshea10 