### PR TITLE
Update customer-service.md

### DIFF
--- a/docs/docs/tutorials/customer-service.md
+++ b/docs/docs/tutorials/customer-service.md
@@ -169,7 +169,7 @@ For a task-oriented dialogue system, you could use the evaluation script to auto
     --model_api http://127.0.0.1:8000/eval/chat \
     --config ./examples/customer_service_config.json \
     --documents_dir ./examples/customer_service \
-    --output-dir ./examples/customer_service
+    --output_dir ./examples/customer_service
     ```
 
 ## Evaluation Results


### PR DESCRIPTION
## Summary
This PR fixed the typo in the documentation of this Repo.


## Description
In the documentation of `docs/docs/tutorials/customer-service.md`, the parameter is shown as `output-dir`, which should actually be `output_dir`.


## Tests
The document can be successfully built and deployed locally, which will also be put to production.


## Reviewers
@xinyang-articulate 