### PR TITLE
Evaluation with Gemini/Anthropic

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ python run.py --input-dir ./examples/customer_service
 
     * Fields:
       * `--input-dir`: The directory that contains the generated files
-      * `--model`: The openai model type used to generate bot response. Default is `gpt-4o`. You could change it to other models like `gpt-4o-mini`.
+       * `--llm_provider`: The LLM provider you wish to use. 
+          - Options: `openai` (default), `gemini`, `anthropic`
+      * `--model`: The model type used to generate bot response. The default is `gpt-4o`. 
+        - You can change this to other models like:
+          - `gpt-4o-mini`,  `gemini-2.0-flash` , `claude-3-5-haiku-20241022`
       * `--port`: The port number to start the api. Default is 8000.
 
   * Then, start the evaluation process: 
@@ -123,6 +127,10 @@ python run.py --input-dir ./examples/customer_service
       * `--num_convos`: Number of synthetic conversations to simulate. Default is 5.
       * `--num_goals`: Number of goals/tasks to simulate. Default is 5.
       * `--max_turns`: Maximum number of turns per conversation. Default is 5.
-      * `--model`: The openai model type used to synthesize user's utterance. Default is `gpt-4o`. You could change it to other models like `gpt-4o-mini`.
+       * `--llm_provider`: The LLM provider you wish to use. 
+          - Options: `openai` (default), `gemini`, `anthropic`
+      * `--model`: The model type used to generate bot response. The default is `gpt-4o`. 
+        - You can change this to other models like:
+          - `gpt-4o-mini`,  `gemini-2.0-flash` , `claude-3-5-haiku-20241022`
   
     📄 For more details, check out the [Evaluation README](https://github.com/arklexai/Agent-First-Organization/blob/main/arklex/evaluation/README.md).

--- a/arklex/utils/graph_state.py
+++ b/arklex/utils/graph_state.py
@@ -67,7 +67,8 @@ class MessageState(BaseModel):
     metadata: Metadata
     # stream
     is_stream: bool
-    message_queue: Any = Field(exclude=True)
+    # message_queue: Any = Field(exclude=True)
+    message_queue: Any = None
 
 
 class PathNode(BaseModel):

--- a/docs/docs/Evaluation/intro.md
+++ b/docs/docs/Evaluation/intro.md
@@ -9,7 +9,11 @@ Here is an example for the customer service assistant chatbot.
     ```
     * Fields:
       * `--input-dir`: The directory that contains the needed files for the orchestrator and documents for the workers.
-      * `--model`: The openai model type used to generate bot response. Default is `gpt-4o`. You could change it to other models like `gpt-4o-mini`.
+       * `--llm_provider`: The LLM provider you wish to use. 
+          - Options: `openai` (default), `gemini`, `anthropic`
+      * `--model`: The model type used to generate bot response. The default is `gpt-4o`. 
+        - You can change this to other models like:
+          - `gpt-4o-mini`,  `gemini-2.0-flash` , `claude-3-5-haiku-20241022`
       * `--port`: The port number to start the API. Default is 8000.
 
 2. Then, start the evaluation process:
@@ -28,7 +32,11 @@ Here is an example for the customer service assistant chatbot.
       * `--num_convos`: Number of synthetic conversations to simulate. Default is 5.
       * `--num_goals`: Number of goals/tasks to simulate. Default is 5.
       * `--max_turns`: Maximum number of turns per conversation. Default is 5.
-      * `--model`: The openai model type used to generate bot response. Default is `gpt-4o`. You could change it to other models like `gpt-4o-mini`.
+       * `--llm_provider`: The LLM provider you wish to use. 
+          - Options: `openai` (default), `gemini`, `anthropic`
+      * `--model`: The model type used to generate bot response. The default is `gpt-4o`. 
+        - You can change this to other models like:
+          - `gpt-4o-mini`,  `gemini-2.0-flash` , `claude-3-5-haiku-20241022`
 
 ## Results
 The evaluation will generate the following outputs in the specified output directory:

--- a/eval.py
+++ b/eval.py
@@ -8,7 +8,8 @@ from arklex.evaluation.extract_conversation_info import extract_task_completion_
 from arklex.evaluation.simulate_second_pass_convos import get_labeled_convos
 # from arklex.evaluation.analyze import analyze_action_accuracy_metrics
 from arklex.utils.model_config import MODEL
-
+from arklex.utils.model_provider_config import LLM_PROVIDERS
+from arklex.evaluation.chatgpt_utils import create_client
 
 def evaluate(config):
     task = config['task']
@@ -50,6 +51,7 @@ if __name__ == "__main__":
     parser.add_argument('--config', type=str)
     parser.add_argument('--output_dir', type=str)
     parser.add_argument('--model', type=str, default=MODEL["model_type_or_path"])
+    parser.add_argument( '--llm-provider',type=str,default=MODEL["llm_provider"],choices=LLM_PROVIDERS)
     parser.add_argument('--customer_type', type=str, default=None, choices=['b2b', 'b2c'])
     parser.add_argument('--task', type=str, default='first_pass', choices=['first_pass', "action_pass", 'all'])
     parser.add_argument('--user_attributes', type=str, default='arklex/evaluation/user_attributes.json')
@@ -59,6 +61,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     MODEL["model_type_or_path"] = args.model
+    MODEL["llm_provider"] = args.llm_provider
+    create_client()
 
     assert args.model_api is not None, "Model api must be provided"
     assert args.config is not None, "Config file must be provided"

--- a/model_api.py
+++ b/model_api.py
@@ -13,6 +13,7 @@ from arklex.utils.utils import init_logger
 from arklex.env.env import Env
 from arklex.orchestrator.orchestrator import AgentOrg
 from arklex.utils.model_config import MODEL
+from arklex.utils.model_provider_config import LLM_PROVIDERS
 
 
 logger = logging.getLogger(__name__)
@@ -48,12 +49,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Start FastAPI with custom config.")
     parser.add_argument('--input-dir', type=str, default="./examples/test")
     parser.add_argument('--model', type=str, default=MODEL["model_type_or_path"])
+    parser.add_argument( '--llm-provider',type=str,default=MODEL["llm_provider"],choices=LLM_PROVIDERS)
     parser.add_argument('--port', type=int, default=8000, help="Port to run the FastAPI app")
     parser.add_argument('--log-level', type=str, default="WARNING", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
     
     args = parser.parse_args()
     os.environ["DATA_DIR"] = args.input_dir
     MODEL["model_type_or_path"] = args.model
+    MODEL["llm_provider"] = args.llm_provider
 
     log_level = getattr(logging, args.log_level.upper(), logging.WARNING)
     logger = init_logger(log_level=log_level, filename=os.path.join(os.path.dirname(__file__), "logs", "arklex.log"))


### PR DESCRIPTION
## Summary

Added support for evaluation with more LLM providers(i.e. Gemini and Anthropic)

- Task: [https://www.notion.so/arklex/Evaluation-for-Gemini-Anthropic-models-1cf2ad772093808281f7d7624bc19b08](https://www.notion.so/1cf2ad772093808281f7d7624bc19b08?pvs=21)

## Description

- Why: Need to make multiple LLM providers compatible with the dev tool. An important & critical step is being able to evaluate the agent.
- How: Made updates to the following files:
    - `docs/docs/Evaluation/intro.md`: added documentation for evaluation for Gemini & Anthropic
    - `README.md`: added how to run `model_api.py` and `eval.py` with Gemini & Anthropic models
    - `eval.py` **and** `model_api.py`**:** added new input args(i.e. llm_provider)
    - `arklex/evaluation/chatgpt_utils.py` : added support for calling the chatbot using different providers
    - `arklex/evaluation/simulate_first_pass_convos.py` : made the `conversation` function be called in parallel inside the `generate_conversations` function

## Tests

Test cases involve running evaluation using Anthropic & Gemini models. Also, verifying the updated documentation.

- [ ]  Test case 1: For OpenAI
    - [ ]  `python model_api.py  --input-dir ./examples/customer_service --model gpt-4o-mini`
    - [ ]  `python eval.py --model_api http://127.0.0.1:8000/eval/chat --output_dir ./examples/customer_service/eval_first_pass_openai --config ./examples/customer_service_config.json --documents_dir ./examples/customer_service --model gpt-4o-mini --task first_pass`
- [ ]  Test case 2: For Gemini
    - [ ]  `python model_api.py  --input-dir ./examples/customer_service --model gemini-2.0-flash --llm-provider gemini`
    - [ ]  `python eval.py --model_api http://127.0.0.1:8000/eval/chat --output_dir ./examples/customer_service/eval_first_pass_gemini --config ./examples/customer_service_config.json --documents_dir ./examples/customer_service --model gemini-2.0-flash --llm-provider gemini --task first_pass`
- [ ]  Test case 3: For Anthropic
    - [ ]  `python model_api.py  --input-dir ./examples/customer_service --model claude-3-5-haiku-20241022 --llm-provider anthropic`
    - [ ]  `python eval.py --model_api http://127.0.0.1:8000/eval/chat --output_dir ./examples/customer_service/eval_first_pass_claude --config ./examples/customer_service_config.json --documents_dir ./examples/customer_service --model claude-3-5-haiku-20241022 --llm-provider anthropic --task first_pass`
- [ ]  Test case 4: Deploy it locally and run the documentation, go to `Evaluation` introduction section

## Reviewers

- @xinyang-articulate
- @luyunan0404