### PR TITLE
disable test files

### DIFF
--- a/.github/workflows/test-resources.yml
+++ b/.github/workflows/test-resources.yml
@@ -1,12 +1,12 @@
 name: Test Resources (workers, tools, etc.)
 
-on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+# on:
+#   pull_request:
+#     branches:
+#       - main
+#   push:
+#     branches:
+#       - main
 
 jobs:
   test-resources:


### PR DESCRIPTION
## Summary
Disable the integration test before merging a PR to the main branch.

## Description
The integration test currently incurs additional cost, and should be able to use cheaper models to save the cost

## Tests
This change has no impact on the current workflow and does not affect the logic


## Reviewers
@luyunan0404 