### PR TITLE
allow global intent re-enter if leaf node

### DIFF
--- a/arklex/orchestrator/task_graph.py
+++ b/arklex/orchestrator/task_graph.py
@@ -271,11 +271,11 @@ class TaskGraph(TaskGraphBase):
                                 "pred_intent": pred_intent, "no_intent": False, "global_intent": True})
             found_pred_in_avil, pred_intent, intent_idx = self._postprocess_intent(pred_intent, available_global_intents)
             # if found prediction and prediction is not unsure intent and current intent
-            # TODO: how to know if user want to proceed or going back to the initial node of the same global intent
             if found_pred_in_avil and \
-                pred_intent != self.unsure_intent.get("intent") and \
-                pred_intent != params.taskgraph.curr_global_intent:
-                params.taskgraph.intent = pred_intent
+                pred_intent != self.unsure_intent.get("intent"):
+                # If the prediction is the same as the current global intent and the current node is not a leaf node, continue the current global intent
+                if pred_intent == params.taskgraph.curr_global_intent and len(list(self.graph.successors(curr_node))) != 0:
+                    return False, pred_intent, {}, params
                 next_node, next_intent = self.jump_to_node(pred_intent, intent_idx, curr_node)
                 logger.info(f"curr_node: {next_node}")
                 node_info, params = self._get_node(next_node, params, intent=next_intent)
@@ -340,7 +340,8 @@ class TaskGraph(TaskGraphBase):
         If unknown intent, call planner
         """
         # if none of the available intents can represent user's utterance, transfer to the planner to let it decide for the next step
-        params.taskgraph.intent = "others"
+        params.taskgraph.intent = self.unsure_intent.get("intent")
+        params.taskgraph.curr_global_intent = ""
         if params.taskgraph.nlu_records:
             params.taskgraph.nlu_records[-1]["no_intent"] = True  # no intent found
         else:


### PR DESCRIPTION
## Summary
The PR is to modify the global intent switch logic in the current taskgraph.


## Description
For the global intent prediction, if it is the same as the last turn
- The node is the leaf node: it could re-enter the same global intent
- The node is not the leaf node: it should continue the current global intent instead of re-entering


## Tests
- Tested the global intent switch where the node is leaf node and it will re-enter the same intent
- Tested the global intent switch where the node is not leaf node and it will continue the current task

## Reviewers
@luyunan0404 
@luigi617 