### PR TITLE
adapt generation to api

### DIFF
--- a/arklex/orchestrator/generator/generator.py
+++ b/arklex/orchestrator/generator/generator.py
@@ -169,7 +169,7 @@ class TaskEditorApp(App):
 
 
 class Generator:
-    def __init__(self, config: dict, model, output_dir: str, resource_inizializer: Optional[BaseResourceInitializer]  = None):
+    def __init__(self, config: dict, model, output_dir: str, resource_inizializer: Optional[BaseResourceInitializer]  = None, interactable_with_user=True):
         if resource_inizializer is None:
             resource_inizializer = DefaulResourceInitializer()
         self.product_kwargs = config
@@ -184,6 +184,7 @@ class Generator:
         self.example_conversations = self.product_kwargs.get("example_conversations") 
         self.workers = resource_inizializer.init_workers(self.product_kwargs.get("workers"))
         self.tools = resource_inizializer.init_tools(self.product_kwargs.get("tools"))
+        self.interactable_with_user = interactable_with_user
         self.model = model
         self.timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         self.output_dir = output_dir
@@ -603,8 +604,11 @@ class Generator:
                 logger.error(e)
                 continue
             format_tasks.append({"task_name": task_name, "steps": steps})
-        app = TaskEditorApp(format_tasks)
-        hitl_result = app.run()
+        
+        hitl_result = format_tasks
+        if self.interactable_with_user:
+            app = TaskEditorApp(hitl_result)
+            hitl_result = app.run()
         task_planning_filepath = os.path.join(self.output_dir, f'taskplanning.json')
         json.dump(hitl_result, open(task_planning_filepath, "w"), indent=4)
 

--- a/arklex/orchestrator/generator/generator.py
+++ b/arklex/orchestrator/generator/generator.py
@@ -169,18 +169,19 @@ class TaskEditorApp(App):
 
 
 class Generator:
-    def __init__(self, args, config, model, output_dir, resource_inizializer: Optional[BaseResourceInitializer]  = None):
+    def __init__(self, config: dict, model, output_dir: str, resource_inizializer: Optional[BaseResourceInitializer]  = None):
         if resource_inizializer is None:
             resource_inizializer = DefaulResourceInitializer()
-        self.args = args
-        self.product_kwargs = json.load(open(config))
+        self.product_kwargs = config
         self.role = self.product_kwargs.get("role")
         self.u_objective = self.product_kwargs.get("user_objective")
         self.b_objective = self.product_kwargs.get("builder_objective")
         self.intro = self.product_kwargs.get("intro")
+        self.instructions = self.product_kwargs.get("instructions") 
         self.task_docs = self.product_kwargs.get("task_docs") 
         self.rag_docs = self.product_kwargs.get("rag_docs") 
         self.tasks = self.product_kwargs.get("tasks")
+        self.example_conversations = self.product_kwargs.get("example_conversations") 
         self.workers = resource_inizializer.init_workers(self.product_kwargs.get("workers"))
         self.tools = resource_inizializer.init_tools(self.product_kwargs.get("tools"))
         self.model = model
@@ -568,7 +569,7 @@ class Generator:
             self.documents = ""
 
 
-    def generate(self):
+    def generate(self) -> dict:
 
         # Step 0: Load the docs
         self._load_docs()
@@ -624,9 +625,10 @@ class Generator:
         # Step 5: Format the task graph
         task_graph = self._format_task_graph(finetuned_best_practices)
 
-        # Step 6: Save the task graph
+        return task_graph
+    
+    def save_task_graph(self, task_graph) -> str:
         taskgraph_filepath = os.path.join(self.output_dir, f'taskgraph.json')
         with open(taskgraph_filepath, "w") as f:
             json.dump(task_graph, f, indent=4)
-
         return taskgraph_filepath

--- a/arklex/orchestrator/generator/generator.py
+++ b/arklex/orchestrator/generator/generator.py
@@ -1,23 +1,19 @@
 import os
 import json
-import argparse
 import logging
 from datetime import datetime
 from tqdm import tqdm as progress_bar
-import subprocess
 import pickle
 from pathlib import Path
 import inspect
-import importlib
 from typing import Optional
 from collections import deque
 
 from langchain.prompts import PromptTemplate
 from langchain_openai.chat_models import ChatOpenAI
-from langchain_core.runnables import RunnableLambda
 from langchain_core.output_parsers import StrOutputParser
 from textual.app import App, ComposeResult
-from textual.widgets import Tree, Label, Input, Button, Static, Log
+from textual.widgets import Tree, Label, Input, Button, Static
 from textual.containers import Vertical, Horizontal
 from textual.screen import Screen
 from textual.widgets.tree import TreeNode
@@ -28,6 +24,8 @@ from arklex.utils.loader import Loader, SourceType
 import sys
 from arklex.env.env import BaseResourceInitializer, DefaulResourceInitializer
 from arklex.env.nested_graph.nested_graph import NESTED_GRAPH_ID
+from arklex.utils.model_config import MODEL
+from arklex.utils.model_provider_config import PROVIDER_MAP
 
 
 logger = logging.getLogger(__name__)
@@ -169,7 +167,9 @@ class TaskEditorApp(App):
 
 
 class Generator:
-    def __init__(self, config: dict, model, output_dir: str, resource_inizializer: Optional[BaseResourceInitializer]  = None, interactable_with_user=True):
+    def __init__(self, config: dict, output_dir: str="", model=None, resource_inizializer: Optional[BaseResourceInitializer]=None, interactable_with_user=False):
+        if model is None:
+            model = PROVIDER_MAP.get(MODEL['llm_provider'], ChatOpenAI)(model=MODEL["model_type_or_path"],timeout=30000)
         if resource_inizializer is None:
             resource_inizializer = DefaulResourceInitializer()
         self.product_kwargs = config
@@ -177,11 +177,9 @@ class Generator:
         self.u_objective = self.product_kwargs.get("user_objective")
         self.b_objective = self.product_kwargs.get("builder_objective")
         self.intro = self.product_kwargs.get("intro")
-        self.instructions = self.product_kwargs.get("instructions") 
         self.task_docs = self.product_kwargs.get("task_docs") 
-        self.rag_docs = self.product_kwargs.get("rag_docs") 
+        # self.rag_docs = self.product_kwargs.get("rag_docs") // Not used for now
         self.tasks = self.product_kwargs.get("tasks")
-        self.example_conversations = self.product_kwargs.get("example_conversations") 
         self.workers = resource_inizializer.init_workers(self.product_kwargs.get("workers"))
         self.tools = resource_inizializer.init_tools(self.product_kwargs.get("tools"))
         self.interactable_with_user = interactable_with_user

--- a/benchmark/tau_bench/tau_bench_eval.py
+++ b/benchmark/tau_bench/tau_bench_eval.py
@@ -110,8 +110,10 @@ def generate_tau_bench_config(output_dir):
 def generate_taskgraph(config_file, output_dir):
     model = ChatOpenAI(model=MODEL["model_type_or_path"], timeout=30000)
     resource_initializer = TauBenchResourceInitializer()
-    generator = Generator(args, config_file, model, output_dir, resource_initializer)
-    taskgraph_filepath = generator.generate()
+    config = json.load(open(config_file))
+    generator = Generator(config, model, output_dir, resource_initializer)
+    taskgraph = generator.generate()
+    taskgraph_filepath = generator.save_task_graph(taskgraph)
     # Update the task graph with the API URLs
     task_graph = json.load(open(os.path.join(root_dir, taskgraph_filepath)))
     task_graph["nluapi"] = NLUAPI_ADDR

--- a/benchmark/tau_bench/tau_bench_eval.py
+++ b/benchmark/tau_bench/tau_bench_eval.py
@@ -111,7 +111,7 @@ def generate_taskgraph(config_file, output_dir):
     model = ChatOpenAI(model=MODEL["model_type_or_path"], timeout=30000)
     resource_initializer = TauBenchResourceInitializer()
     config = json.load(open(config_file))
-    generator = Generator(config, model, output_dir, resource_initializer)
+    generator = Generator(config, output_dir, model, resource_initializer, interactable_with_user=True)
     taskgraph = generator.generate()
     taskgraph_filepath = generator.save_task_graph(taskgraph)
     # Update the task graph with the API URLs

--- a/create.py
+++ b/create.py
@@ -23,8 +23,10 @@ load_dotenv()
 
 def generate_taskgraph(args):
     model = PROVIDER_MAP.get(MODEL['llm_provider'], ChatOpenAI)(model=MODEL["model_type_or_path"],timeout=30000)
-    generator = Generator(args, args.config, model, args.output_dir)
-    taskgraph_filepath = generator.generate()
+    config = json.load(open(args.config))
+    generator = Generator(config, model, args.output_dir)
+    taskgraph = generator.generate()
+    taskgraph_filepath = generator.save_task_graph(taskgraph)
     # Update the task graph with the API URLs
     task_graph = json.load(open(os.path.join(os.path.dirname(__file__), taskgraph_filepath)))
     task_graph["nluapi"] = ""

--- a/create.py
+++ b/create.py
@@ -1,17 +1,12 @@
 import os
 import json
 import argparse
-import time
 import logging
-import subprocess
-import signal
-import atexit
 from dotenv import load_dotenv
 
 from langchain_openai import ChatOpenAI
 
 from arklex.utils.utils import init_logger
-from arklex.orchestrator.orchestrator import AgentOrg
 from arklex.orchestrator.generator.generator import Generator
 from arklex.env.tools.RAG.build_rag import build_rag
 from arklex.env.tools.database.build_database import build_database
@@ -24,7 +19,7 @@ load_dotenv()
 def generate_taskgraph(args):
     model = PROVIDER_MAP.get(MODEL['llm_provider'], ChatOpenAI)(model=MODEL["model_type_or_path"],timeout=30000)
     config = json.load(open(args.config))
-    generator = Generator(config, model, args.output_dir)
+    generator = Generator(config, args.output_dir, model, interactable_with_user=True)
     taskgraph = generator.generate()
     taskgraph_filepath = generator.save_task_graph(taskgraph)
     # Update the task graph with the API URLs


### PR DESCRIPTION
## Summary
Adapt generator class to API for hub

## Description
- Change generator input (remove args, and config dict rather than config file path)
- When generating, task graph won't be saved (need to call another function for saving)
- generator output is dict now

## Tests
- test with customer config file
- test with taubench ecommerce config file

## Reviewers
- @xinyang-articulate 
- @luyunan0404 
