### PR TITLE
add milvus tag for rag

### DIFF
--- a/arklex/env/env.py
+++ b/arklex/env/env.py
@@ -8,7 +8,7 @@ from functools import partial
 from arklex.env.tools.tools import Tool
 from arklex.env.workers.worker import BaseWorker
 from arklex.env.planner.function_calling import FunctionCallingPlanner
-from arklex.utils.graph_state import Params, MessageState
+from arklex.utils.graph_state import Params, MessageState, NodeInfo
 from arklex.orchestrator.NLU.nlu import SlotFilling
 
 
@@ -91,7 +91,8 @@ class Env():
     def step(self, 
              id: str, 
              message_state: MessageState, 
-             params: Params):
+             params: Params,
+             node_info: NodeInfo):
         if id in self.tools:
             logger.info(f"{self.tools[id]['name']} tool selected")
             tool: Tool = self.tools[id]["execute"]()
@@ -109,7 +110,7 @@ class Env():
             # If the worker need to do the slotfilling, then it should have this method
             if hasattr(worker, "init_slotfilling"):
                 worker.init_slotfilling(self.slotfillapi)
-            response_state = worker.execute(message_state)
+            response_state = worker.execute(message_state, **node_info.additional_args)
             call_id = str(uuid.uuid4())
             params.memory.function_calling_trajectory.append({
                 'content': None, 

--- a/arklex/env/tools/RAG/retrievers/milvus_retriever.py
+++ b/arklex/env/tools/RAG/retrievers/milvus_retriever.py
@@ -171,7 +171,7 @@ class MilvusRetriever:
 
         updated_vectors = []
         for vector_data in res:
-            updated_vector = vector_data.copy()
+            updated_vector = vector_data
             if updated_vector.get("metadata", {}):
                 updated_vector["metadata"]["tags"] = tags
             else:
@@ -269,13 +269,6 @@ class MilvusRetriever:
         partition_key = self.get_bot_uid(bot_id, version)
         query_embedding = embed(query)
         filter = f'bot_uid == "{partition_key}"'
-        res = self.client.search(
-            collection_name=collection_name,
-            data=[query_embedding],
-            limit=top_k,
-            filter=filter,
-            output_fields=["qa_doc_id", "chunk_id", "qa_doc_type", "metadata", "text"],
-        )
         if tags:
             # NOTE: Only support one tag for now
             for key, value in tags.items():

--- a/arklex/env/workers/worker.py
+++ b/arklex/env/workers/worker.py
@@ -22,12 +22,12 @@ class BaseWorker(ABC):
         return f"{self.__class__.__name__}"
     
     @abstractmethod
-    def _execute(self, msg_state: MessageState):
+    def _execute(self, msg_state: MessageState, **kwargs):
         pass
 
-    def execute(self, msg_state: MessageState):
+    def execute(self, msg_state: MessageState, **kwargs):
         try:
-            response_return = self._execute(msg_state)
+            response_return = self._execute(msg_state, **kwargs)
             response_state = MessageState.model_validate(response_return)
             response_state.trajectory[-1][-1].output = response_state.response if response_state.response else response_state.message_flow
             if response_state.status == StatusEnum.INCOMPLETE:

--- a/arklex/orchestrator/orchestrator.py
+++ b/arklex/orchestrator/orchestrator.py
@@ -167,7 +167,7 @@ class AgentOrg:
         message_state.is_stream = True if stream_type is not None else False
         message_state.message_queue = message_queue
         
-        response_state, params = self.env.step(node_info.resource_id, message_state, params)
+        response_state, params = self.env.step(node_info.resource_id, message_state, params, node_info)
         params.memory.trajectory = response_state.trajectory
         return node_info, response_state, params
     

--- a/arklex/orchestrator/task_graph.py
+++ b/arklex/orchestrator/task_graph.py
@@ -125,7 +125,8 @@ class TaskGraph(TaskGraphBase):
             can_skipped=True,
             is_leaf=len(list(self.graph.successors(sample_node))) == 0,
             attributes=node_info["attribute"],
-            add_flow_stack=False
+            add_flow_stack=False,
+            additional_args={"tags": node_info["attribute"].get("tags", {})}
         )
         
         return node_info, params
@@ -228,7 +229,8 @@ class TaskGraph(TaskGraphBase):
                 resource_name = resource_name,
                 can_skipped=False,
                 is_leaf=len(list(self.graph.successors(curr_node))) == 0,
-                attributes=node_info["attribute"]
+                attributes=node_info["attribute"],
+                additional_args={"tags": node_info["attribute"].get("tags", {})}
             )
             return True, node_info, params
         return False, NodeInfo(), params
@@ -349,7 +351,8 @@ class TaskGraph(TaskGraphBase):
             resource_name = "planner",
             can_skipped=False,
             is_leaf=len(list(self.graph.successors(curr_node))) == 0,
-            attributes = {"value": "", "direct": False}
+            attributes = {"value": "", "direct": False},
+            additional_args = {"tags": {}}
         )
         return node_info, params
         

--- a/arklex/utils/graph_state.py
+++ b/arklex/utils/graph_state.py
@@ -119,6 +119,7 @@ class NodeInfo(BaseModel):
     is_leaf: bool = Field(default=False)
     attributes: Dict[str, Any] = Field(default_factory=dict)
     add_flow_stack: Optional[bool] = Field(default=False)
+    additional_args: Optional[dict] = Field(default={})
 
 class OrchestratorResp(BaseModel):
     answer: str = Field(default="")

--- a/examples/milvus_filter/taskgraph.json
+++ b/examples/milvus_filter/taskgraph.json
@@ -1,0 +1,86 @@
+{
+    "nodes": [
+        [
+            "0",
+            {
+                "resource": {
+                    "id": "message_worker",
+                    "name": "MessageWorker"
+                },
+                "attribute": {
+                    "value": "Hello! I'm here to assist you with any customer service inquiries you may have. Whether you need information about our products, services, or policies, or if you need help with any issues or transactions, feel free to ask. How can I assist you today?",
+                    "task": "start message",
+                    "directed": false
+                },
+                "limit": 1,
+                "type": "start"
+            }
+        ],
+        [
+            "1",
+            {
+                "resource": {
+                    "id": "milvus_rag_worker",
+                    "name": "MilvusRAGWorker"
+                },
+                "attribute": {
+                    "value": "",
+                    "task": "Answer the user's question related to robots with the retrieved information from Milvus",
+                    "directed": false,
+                    "tags": {
+                        "product": "robots"
+                    }
+                },
+                "limit": 1
+            }
+        ]
+    ],
+    "edges": [
+        [
+            "0",
+            "1",
+            {
+                "intent": "User seeks information about robots",
+                "attribute": {
+                    "weight": 1,
+                    "pred": true,
+                    "definition": "",
+                    "sample_utterances": []
+                }
+            }
+        ]
+    ],
+    "role": "customer service assistant",
+    "user_objective": "The customer service assistant helps users with customer service inquiries. It can provide information about products, services, and policies, as well as help users resolve issues and complete transactions.",
+    "builder_objective": "The customer service assistant helps to request customer's contact information.",
+    "domain": "robotics and automation",
+    "intro": "Richtech Robotics's headquarter is in Las Vegas; the other office is in Austin. Richtech Robotics provide worker robots (ADAM, ARM, ACE), delivery robots (Matradee, Matradee X, Matradee L, Richie), cleaning robots (DUST-E SX, DUST-E MX) and multipurpose robots (skylark). Their products are intended for business purposes, but not for home purpose; the ADAM robot is available for purchase and rental for multiple purposes. This robot bartender makes tea, coffee and cocktails. Richtech Robotics also operate the world's first robot milk tea shop, ClouTea, in Las Vegas (www.cloutea.com), where all milk tea beverages are prepared by the ADAM robot. The delivery time will be one month for the delivery robot, 2 weeks for standard ADAM, and two months for commercial cleaning robot. ",
+    "task_docs": [
+        {
+            "source": "https://www.richtechrobotics.com/",
+            "num": 20
+        }
+    ],
+    "rag_docs": [
+        {
+            "source": "https://www.richtechrobotics.com/",
+            "num": 20
+        }
+    ],
+    "tasks": [],
+    "workers": [
+        {
+            "id": "milvus_rag_worker",
+            "name": "MilvusRAGWorker",
+            "path": "milvus_rag_worker.py"
+        },
+        {
+            "id": "message_worker",
+            "name": "MessageWorker",
+            "path": "message_worker.py"
+        }
+    ],
+    "tools": [],
+    "nluapi": "",
+    "slotfillapi": ""
+}


### PR DESCRIPTION
## Summary
The PR is to add tags when using Milvus vector database for crawling and RAG


## Description
- Add a Milvus operation to update tags for given `qa_doc_id`
- Pass in tags as an additional args when executing the `MilvusRagWorker` and `RagMsgworker` (can be expanded to other use cases)
- Tag with be used as a filter to get relevant docs (only docs with the same tag will be searched)


## Tests
When a hard-coded tag is applied to a RAG node, only docs with the tag will be returned as rouce.
- [x] Tested FAQ with tag and without tag in local Hub
- [x] Tested URL with tag and without tag in local Hub
- [x] Tested File with tag and without tag in local Hub
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/70643574-a8ab-4927-83ed-fd6324b4678d" />


## Reviewers
@luyunan0404 