### PR TITLE
fix tags for workers

### DIFF
--- a/arklex/env/workers/faiss_rag_worker.py
+++ b/arklex/env/workers/faiss_rag_worker.py
@@ -42,7 +42,7 @@ class FaissRAGWorker(BaseWorker):
             "retriever", self.choose_tool_generator)
         return workflow
 
-    def _execute(self, msg_state: MessageState):
+    def _execute(self, msg_state: MessageState, **kwargs):
         graph = self.action_graph.compile()
         result = graph.invoke(msg_state)
         return result

--- a/arklex/env/workers/hitl_worker.py
+++ b/arklex/env/workers/hitl_worker.py
@@ -128,7 +128,7 @@ class HITLWorker(BaseWorker):
         workflow.add_edge(START, "hitl")
         return workflow
         
-    def _execute(self, state: MessageState) -> MessageState:
+    def _execute(self, state: MessageState, **kwargs) -> MessageState:
         if not self.verify(state):
             return self.error(state)
         

--- a/arklex/env/workers/message_worker.py
+++ b/arklex/env/workers/message_worker.py
@@ -104,7 +104,7 @@ class MessageWorker(BaseWorker):
         workflow.add_conditional_edges(START, self.choose_generator)
         return workflow
 
-    def _execute(self, msg_state: MessageState):
+    def _execute(self, msg_state: MessageState, **kwargs):
         self.llm = PROVIDER_MAP.get(msg_state.bot_config.llm_config.llm_provider, ChatOpenAI)(
             model=msg_state.bot_config.llm_config.model_type_or_path
         )

--- a/arklex/env/workers/search_worker.py
+++ b/arklex/env/workers/search_worker.py
@@ -32,7 +32,7 @@ class SearchWorker(BaseWorker):
         workflow.add_edge("search_engine", "tool_generator")
         return workflow
 
-    def _execute(self, msg_state: MessageState):
+    def _execute(self, msg_state: MessageState, **kwargs):
         graph = self.action_graph.compile()
         result = graph.invoke(msg_state)
         return result


### PR DESCRIPTION
## Summary
The PR https://github.com/arklexai/Agent-First-Organization/pull/100 is about adding tags to Milvus-related workers. Other workers should be able to parse the tags input even not using it.


## Description
The default execution method of worker should handle tag input even if not using it

Logs from DataDog:
https://us5.datadoghq.com/logs?query=host%3Ai-06db748c8297c5aea%20service%3Aqa-server-bot%20container_id%3A128d5ea8a9451146c0d10b6c29d94caaee8cab031c9c656b7c48d2df474b5ff6%20filename%3A0.log&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZa3x_VjAACast5xbo-0PQAb&event=&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&to_event=AwAAAZa3x-donTTrogAAABhBWmEzeF9WakFBQ2FzdDV4Ym8tMFBRQWwAAAAkMDE5NmI4NTktOTE5Zi00ZTE0LWIwYjEtNWYwZmMxMzdkMjM5AAMFbw&viz=&from_ts=1746839752730&to_ts=1746840053609&live=false




## Tests
Run the broken message worker and it has been fixed.
Milvus-related workers are not affected.


## Reviewers
@luyunan0404 