### PR TITLE
Fix the problem of retrieving the meeting_links

### DIFF
--- a/arklex/env/tools/hubspot/check_available.py
+++ b/arklex/env/tools/hubspot/check_available.py
@@ -93,6 +93,7 @@ def check_available(
                 func_name, HubspotExceptionPrompt.MEETING_LINK_UNFOUND_PROMPT
             )
         else:
+            # Emphasize on the results part of the response
             if not meeting_link_response.get("results"):
                 logger.error(
                     f"The error for retrieving the meeting link happens:{meeting_link_response.get('message', 'Unknown error happens')}"
@@ -101,14 +102,18 @@ def check_available(
                     func_name, HubspotExceptionPrompt.MEETING_LINK_UNFOUND_PROMPT
                 )
             else:
+                # Extract the corresponsing link of the specific user
                 meeting_links_ls: List[Dict[str, Any]] = [
                     item
                     for item in meeting_link_response.get("results")
                     if item.get("organizerUserId") == str(owner_id)
                 ]
+
+                # Get the first link of someone
                 if len(meeting_links) != 0:
                     meeting_links: Dict[str, Any] = meeting_links_ls[0]
                 else:
+                    # The length is 0, then raise error
                     logger.error(
                         f"There is no meeting links corresponding to the owner's id."
                     )

--- a/arklex/env/tools/hubspot/check_available.py
+++ b/arklex/env/tools/hubspot/check_available.py
@@ -110,7 +110,7 @@ def check_available(
                 ]
 
                 # Get the first link of someone
-                if len(meeting_links) != 0:
+                if len(meeting_links_ls) != 0:
                     meeting_links: Dict[str, Any] = meeting_links_ls[0]
                 else:
                     # The length is 0, then raise error

--- a/arklex/env/tools/hubspot/check_available.py
+++ b/arklex/env/tools/hubspot/check_available.py
@@ -11,7 +11,9 @@ from arklex.env.tools.hubspot.utils import authenticate_hubspot
 from arklex.exceptions import ToolExecutionError
 from arklex.env.tools.hubspot._exception_prompt import HubspotExceptionPrompt
 
-description: str = "Give the customer that the unavailable time of the specific representative and the representative's related meeting link information."
+description: str = (
+    "Give the customer that the unavailable time of the specific representative and the representative's related meeting link information."
+)
 
 slots: List[Dict[str, Any]] = [
     {
@@ -78,11 +80,12 @@ def check_available(
                 "path": "/scheduler/v3/meetings/meeting-links",
                 "method": "GET",
                 "headers": {"Content-Type": "application/json"},
-                "qs": {"organizerUserId": int(owner_id)},
             }
         )
         meeting_link_response: Dict[str, Any] = meeting_link_response.json()
-        if meeting_link_response.get("status") == "error":
+        if meeting_link_response.get("status") == "error" or meeting_link_response.get(
+            "error"
+        ):
             logger.error(
                 f"The error for retrieving the meeting link happens:{meeting_link_response.get('message', 'Unknown error happens')}"
             )
@@ -90,7 +93,28 @@ def check_available(
                 func_name, HubspotExceptionPrompt.MEETING_LINK_UNFOUND_PROMPT
             )
         else:
-            meeting_links: Dict[str, Any] = meeting_link_response["results"][0]
+            if not meeting_link_response.get("results"):
+                logger.error(
+                    f"The error for retrieving the meeting link happens:{meeting_link_response.get('message', 'Unknown error happens')}"
+                )
+                raise ToolExecutionError(
+                    func_name, HubspotExceptionPrompt.MEETING_LINK_UNFOUND_PROMPT
+                )
+            else:
+                meeting_links_ls: List[Dict[str, Any]] = [
+                    item
+                    for item in meeting_link_response.get("results")
+                    if item.get("organizerUserId") == str(owner_id)
+                ]
+                if len(meeting_links) != 0:
+                    meeting_links: Dict[str, Any] = meeting_links_ls[0]
+                else:
+                    logger.error(
+                        f"There is no meeting links corresponding to the owner's id."
+                    )
+                    raise ToolExecutionError(
+                        func_name, HubspotExceptionPrompt.MEETING_LINK_UNFOUND_PROMPT
+                    )
 
         meeting_slug: str = meeting_links["slug"]
         cal: parsedatetime.Calendar = parsedatetime.Calendar()


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- This PR mainly focuses on fixing the bugs brought from retrieving meeting links. 
- I have changed the logic to check whether the response is good or not because the structure of the error response is different depending on the situations.


## Description
<!-- Provide detailed information about the changes -->
- On the staging hub, the testing result is unstable. Four out of five tests are passed but only one failed due to the previous issue. 
- I made sure every cases in my consideration to raise the tool failure errors.
- The error messages I have encountered have various structures. To be honest, I am not sure whether I included all cases. But I have tried stricter logical check, I think it should be good.


## Tests
<!-- How did you verify these changes? -->
- [x] Test case 1: I have tested on the local staging part. I have tested about four times. Every cases passed. Below are the screenshot of one time. 
![屏幕截图 2025-05-21 162139](https://github.com/user-attachments/assets/4821b9d5-4982-4da8-a167-784db8f6d72c)
![屏幕截图 2025-05-21 162146](https://github.com/user-attachments/assets/45603e1a-629a-411e-8eae-6e829abdb5f0)
![屏幕截图 2025-05-21 162150](https://github.com/user-attachments/assets/9a5a763c-1ba5-469d-b156-00eb0f23719d)



## Reviewers
<!-- Mention the reviewers for this PR -->
- @xinyang-articulate @yongwhan 