### PR TITLE
Fix the error of unable to switch the nodes from different intents

### DIFF
--- a/arklex/orchestrator/task_graph.py
+++ b/arklex/orchestrator/task_graph.py
@@ -293,6 +293,7 @@ class TaskGraph(TaskGraphBase):
             node_info: NodeInfo
             node_info, params = self._get_node(curr_node, params)
             return True, node_info, params
+
         return False, {}, params
 
     def global_intent_prediction(
@@ -351,8 +352,9 @@ class TaskGraph(TaskGraphBase):
                 # If the prediction is the same as the current global intent and the current node is not a leaf node, continue the current global intent
                 if (
                     pred_intent == params.taskgraph.curr_global_intent
-                    and len(list(self.graph.successors(curr_node))) != 0 
-                    or params.taskgraph.node_status.get(curr_node, StatusEnum.COMPLETE) == StatusEnum.INCOMPLETE
+                    and len(list(self.graph.successors(curr_node))) != 0
+                    and params.taskgraph.node_status.get(curr_node, StatusEnum.INCOMPLETE)
+                    == StatusEnum.INCOMPLETE
                 ):
                     return False, pred_intent, {}, params
                 next_node: str
@@ -396,9 +398,9 @@ class TaskGraph(TaskGraphBase):
             node_info: NodeInfo
             node_info, params = self._get_node(next_node, params)
             if params.taskgraph.nlu_records:
-                params.taskgraph.nlu_records[-1]["no_intent"] = (
-                    True  # move on to the next node
-                )
+                params.taskgraph.nlu_records[-1][
+                    "no_intent"
+                ] = True  # move on to the next node
             else:  # only others available
                 params.taskgraph.nlu_records = [
                     {

--- a/arklex/orchestrator/task_graph.py
+++ b/arklex/orchestrator/task_graph.py
@@ -353,7 +353,9 @@ class TaskGraph(TaskGraphBase):
                 if (
                     pred_intent == params.taskgraph.curr_global_intent
                     and len(list(self.graph.successors(curr_node))) != 0
-                    and params.taskgraph.node_status.get(curr_node, StatusEnum.INCOMPLETE)
+                    and params.taskgraph.node_status.get(
+                        curr_node, StatusEnum.INCOMPLETE
+                    )
                     == StatusEnum.INCOMPLETE
                 ):
                     return False, pred_intent, {}, params


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- Fix the issue of not switching nodes from different intents
- Modification on task_graph.py


## Description
<!-- Provide detailed information about the changes -->
- It is urgent to switch the node when user has different intent
- Change the logical check



## Tests
<!-- How did you verify these changes? -->
- [x] Test case 1: acuity book info session to check the effect (origin of the last modification)
- [x] Test case 2: hubspot directly change the intent to test


## Reviewers
<!-- Mention the reviewers for this PR -->
- @xinyang-articulate @yongwhan 