### PR TITLE
update user simulator

### DIFF
--- a/arklex/evaluation/simulate_first_pass_convos.py
+++ b/arklex/evaluation/simulate_first_pass_convos.py
@@ -170,16 +170,13 @@ def conversation(
         output: str = chatgpt_chatbot(history, env_config["client"])
         history.append({"role": "assistant", "content": output})
         chatbot_history.append({"role": "assistant", "content": output})
-        curr_node: str = model_params.get("curr_node", "start")
         response_data: Dict[str, Any] = query_chatbot(
             model_api, chatbot_history, model_params, env_config
         )
         answer: str = response_data["answer"]
         answer = answer.replace("\n", " ")
         model_params = response_data["parameters"]
-        history[-1]["intent"] = model_params["taskgraph"][
-            "curr_global_intent"
-        ]  ## TODO: After add global intent, change to global intent, the current intent if the last intent of each turn
+        history[-1]["intent"] = model_params["taskgraph"]["curr_global_intent"]
         history[-1]["curr_node"] = model_params["taskgraph"]["curr_node"]
         history[-1]["trajectory"] = model_params["memory"]["trajectory"][-1]
 

--- a/arklex/evaluation/simulate_first_pass_convos.py
+++ b/arklex/evaluation/simulate_first_pass_convos.py
@@ -265,53 +265,59 @@ def simulate_conversations(
     synthetic_data_params: Dict[str, Any],
     config: Dict[str, Any],
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
-    profiles, goals, attributes_list, system_inputs, labels_list = build_profile(
-        synthetic_data_params, config
-    )
+    if config["task"] == "first_pass":
+        profiles, goals, attributes_list, system_inputs, labels_list = build_profile(
+            synthetic_data_params, config
+        )
 
-    # save the profiles, goals, attributes_list, system_inputs, labels_list in a json file
-    os.makedirs(os.path.join(config["output_dir"], "simulate_data"), exist_ok=True)
-    with open(
-        os.path.join(config["output_dir"], "simulate_data", "profiles.json"), "w"
-    ) as f:
-        json.dump(profiles, f, indent=4)
-    with open(
-        os.path.join(config["output_dir"], "simulate_data", "goals.json"), "w"
-    ) as f:
-        json.dump(goals, f, indent=4)
-    with open(
-        os.path.join(config["output_dir"], "simulate_data", "attributes_list.json"), "w"
-    ) as f:
-        json.dump(attributes_list, f, indent=4)
-    with open(
-        os.path.join(config["output_dir"], "simulate_data", "system_inputs.json"), "w"
-    ) as f:
-        json.dump(system_inputs, f, indent=4)
-    with open(
-        os.path.join(config["output_dir"], "simulate_data", "labels_list.json"), "w"
-    ) as f:
-        json.dump(labels_list, f, indent=4)
+        # save the profiles, goals, attributes_list, system_inputs, labels_list in a json file
+        os.makedirs(os.path.join(config["output_dir"], "simulate_data"), exist_ok=True)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "profiles.json"), "w"
+        ) as f:
+            json.dump(profiles, f, indent=4)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "goals.json"), "w"
+        ) as f:
+            json.dump(goals, f, indent=4)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "attributes_list.json"),
+            "w",
+        ) as f:
+            json.dump(attributes_list, f, indent=4)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "system_inputs.json"),
+            "w",
+        ) as f:
+            json.dump(system_inputs, f, indent=4)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "labels_list.json"), "w"
+        ) as f:
+            json.dump(labels_list, f, indent=4)
 
-    # with open(
-    #     os.path.join(config["output_dir"], "simulate_data", "profiles.json"), "r"
-    # ) as f:
-    #     profiles = json.load(f)
-    # with open(
-    #     os.path.join(config["output_dir"], "simulate_data", "goals.json"), "r"
-    # ) as f:
-    #     goals = json.load(f)
-    # with open(
-    #     os.path.join(config["output_dir"], "simulate_data", "attributes_list.json"), "r"
-    # ) as f:
-    #     attributes_list = json.load(f)
-    # with open(
-    #     os.path.join(config["output_dir"], "simulate_data", "system_inputs.json"), "r"
-    # ) as f:
-    #     system_inputs = json.load(f)
-    # with open(
-    #     os.path.join(config["output_dir"], "simulate_data", "labels_list.json"), "r"
-    # ) as f:
-    #     labels_list = json.load(f)
+    elif config["task"] == "simulate_conv_only":
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "profiles.json"), "r"
+        ) as f:
+            profiles = json.load(f)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "goals.json"), "r"
+        ) as f:
+            goals = json.load(f)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "attributes_list.json"),
+            "r",
+        ) as f:
+            attributes_list = json.load(f)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "system_inputs.json"),
+            "r",
+        ) as f:
+            system_inputs = json.load(f)
+        with open(
+            os.path.join(config["output_dir"], "simulate_data", "labels_list.json"), "r"
+        ) as f:
+            labels_list = json.load(f)
 
     summary: str = config["intro"]
     env_config: Dict[str, Any] = {

--- a/arklex/orchestrator/task_graph.py
+++ b/arklex/orchestrator/task_graph.py
@@ -332,6 +332,7 @@ class TaskGraph(TaskGraphBase):
                 if next_node != curr_node and list(self.graph.successors(curr_node)):
                     node_info.add_flow_stack = True
                 params.taskgraph.curr_global_intent = pred_intent
+                params.taskgraph.intent = pred_intent
                 return True, pred_intent, node_info, params
         return False, pred_intent, {}, params
 
@@ -425,7 +426,7 @@ class TaskGraph(TaskGraphBase):
         """
         # if none of the available intents can represent user's utterance, transfer to the planner to let it decide for the next step
         params.taskgraph.intent = self.unsure_intent.get("intent")
-        params.taskgraph.curr_global_intent = ""
+        params.taskgraph.curr_global_intent = self.unsure_intent.get("intent")
         if params.taskgraph.nlu_records:
             params.taskgraph.nlu_records[-1]["no_intent"] = True  # no intent found
         else:

--- a/eval.py
+++ b/eval.py
@@ -23,7 +23,7 @@ def evaluate(
     bot_goal: Optional[str] = config.get("builder_objective", None)
     bot_goal = None if bot_goal == "" else bot_goal
 
-    if task == "first_pass":
+    if task == "first_pass" or task == "simulate_conv_only":
         # first pass
         first_pass_data, goals = simulate_conversations(
             model_api, model_params, synthetic_data_params, config
@@ -61,7 +61,10 @@ if __name__ == "__main__":
         "--customer_type", type=str, default=None, choices=["b2b", "b2c"]
     )
     parser.add_argument(
-        "--task", type=str, default="first_pass", choices=["first_pass", "all"]
+        "--task",
+        type=str,
+        default="first_pass",
+        choices=["first_pass", "simulate_conv_only", "all"],
     )
     parser.add_argument(
         "--user_attributes", type=str, default="arklex/evaluation/user_attributes.json"


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- Update the user simulator to generate conversation with id so that the generated conversation with the same profile has the same id instead of getting random sequence from multithread


## Description
<!-- Provide detailed information about the changes -->
- When rerun the user simulator with the same profiles but updated taskgraph config, we want to compare the matching performance. 
- Assign id for the profile and corresponding generated conversation. As long as the profile doesn't change, the conversation_id will be the same.
- For all the unknown intent, assign "others" (which is the unsure intent).
- Doesn't affect the core Agent response functionality.


## Tests
<!-- How did you verify these changes? -->
- [x] Test case 1: user simulator for the shopify case by using shopify_config.json and taskgraph.json


## Reviewers
<!-- Mention the reviewers for this PR -->
- @xinyang-articulate