### PR TITLE
fix hitl tag error

### DIFF
--- a/arklex/env/workers/hitl_worker.py
+++ b/arklex/env/workers/hitl_worker.py
@@ -258,7 +258,7 @@ class HITLWorkerChatFlag(HITLWorker):
 
         return True, message
 
-    def _execute(self, state: MessageState) -> MessageState:
+    def _execute(self, state: MessageState, **kwargs: Any) -> MessageState:
         if not state.metadata.hitl:
             need_hitl: bool
             message: str
@@ -309,7 +309,7 @@ class HITLWorkerMCFlag(HITLWorker):
     def verify_literal(self, message: str) -> bool:
         return "buy" in message
 
-    def _execute(self, state: MessageState) -> MessageState:
+    def _execute(self, state: MessageState, **kwargs: Any) -> MessageState:
         if not state.metadata.hitl:
             need_hitl: bool
             _: str


### PR DESCRIPTION
## Summary
The tag as an additional args will cause an error for the HITL worker.


## Description
The tag as an additional args will cause an error for the HITL worker.


## Tests
This is a standalone component (HITL worker) in the package and should not impact other functions.


## Reviewers
@yongwhan 