### PR TITLE
allow short-term-memory only with intent and past record

### DIFF
--- a/arklex/__init__.py
+++ b/arklex/__init__.py
@@ -15,4 +15,4 @@ Key Components:
 For more information, visit: https://github.com/Agent-First-Organization/Arklex
 """
 
-__version__ = "0.0.16-rc.2"
+__version__ = "0.0.16"

--- a/arklex/orchestrator/orchestrator.py
+++ b/arklex/orchestrator/orchestrator.py
@@ -538,7 +538,8 @@ Answer with only 'yes' or 'no'"""
         max_n_node_performed = 5
         while n_node_performed < max_n_node_performed:
             taskgraph_start_time = time.time()
-            if found_intent:
+            # If there is relevant intent and records in short term memory, do generation based on past context
+            if found_intent and found_records:
                 taskgraph_inputs["allow_global_intent_switch"] = False
                 node_info = NodeInfo(
                     node_id=None,


### PR DESCRIPTION
## Summary
Change the logic of applying short term memory (which can skip intent detection)

## Description
The old short-term-memory can be invoked as long as there is a matched intent from past chat history. However, if there is no past records (context) found, the generation will be purely based on conversation history. To solve this problem, it is better to invoke short-term-memory with more strict rules.


## Tests
Short term memory can still be invoked when both past intents and records found; otherwise it will go through the intent detection workflow.


## Reviewers
@yongwhan 