### PR TITLE
fix hitl message

### DIFF
--- a/arklex/env/workers/hitl_worker.py
+++ b/arklex/env/workers/hitl_worker.py
@@ -281,9 +281,7 @@ class HITLWorkerChatFlag(HITLWorker):
             if not need_hitl:
                 return self.fallback(state)
 
-            state.response = (
-                "[[sending confirmation : this should not show up for user]]"
-            )
+            state.message_flow = message
             state.metadata.hitl = "live"
             state.status = StatusEnum.STAY
 


### PR DESCRIPTION
## Summary
Fix human-in-the-loop worker response message.


## Description
Fix human-in-the-loop worker response message (do context generation instead of fixed message).


## Tests
Tested human-in-the-loop worker and it worked as expected (response message).


## Reviewers
@luyunan0404 
@yongwhan 