### PR TITLE
feat: create test-coverage.yml in github action workflow

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       SHOPIFY_FIXED_ARGS: ${{ secrets.SHOPIFY_FIXED_ARGS }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      MIN_COVERAGE_THRESHOLD: '95'
+      MIN_COVERAGE_THRESHOLD: '98'
 
     steps:
       - name: Checkout
@@ -28,39 +28,36 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e '.[milvus,shopify,hubspot]' --quiet
 
-      - name: Test with pytest
+      - name: Run tests and check coverage threshold
         run: |
+          # Run tests with coverage and generate all reports
           pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=html --cov-report=xml --no-cov-on-fail
-
-      - name: Check coverage threshold
-        run: |
-          # Install coverage tool if not already installed
-          pip install coverage
           
-          # Generate coverage report and extract total coverage
-          coverage run -m pytest tests/ --no-cov-on-fail
-          coverage xml
-          
-          # Extract coverage percentage from XML using Python
+          # Extract coverage percentage from the XML report
           python -c "
           import xml.etree.ElementTree as ET
           import os
           
-          tree = ET.parse('coverage.xml')
-          root = tree.getroot()
-          coverage = float(root.attrib['line-rate']) * 100
-          print(f'Coverage: {coverage:.1f}%')
-          
-          # Get minimum coverage threshold from environment variable
-          min_coverage = float(os.environ.get('MIN_COVERAGE_THRESHOLD', '95'))
-          print(f'Minimum coverage threshold: {min_coverage}%')
-          
-          if coverage < min_coverage:
-              print(f'❌ Coverage ({coverage:.1f}%) is below minimum threshold ({min_coverage}%)')
-              print('This PR will be blocked until coverage is improved.')
+          try:
+              tree = ET.parse('coverage.xml')
+              root = tree.getroot()
+              coverage = float(root.attrib['line-rate']) * 100
+              print(f'Coverage: {coverage:.1f}%')
+              
+              # Get minimum coverage threshold from environment variable
+              min_coverage = float(os.environ.get('MIN_COVERAGE_THRESHOLD', '98'))
+              print(f'Minimum coverage threshold: {min_coverage}%')
+              
+              if coverage < min_coverage:
+                  print(f'❌ Coverage ({coverage:.1f}%) is below minimum threshold ({min_coverage}%)')
+                  print('This PR will be blocked until coverage is improved.')
+                  exit(1)
+              else:
+                  print(f'✅ Coverage ({coverage:.1f}%) meets minimum threshold ({min_coverage}%)')
+          except Exception as e:
+              print(f'Error reading coverage data: {e}')
+              print('❌ Could not determine coverage. Please check the test output.')
               exit(1)
-          else:
-              print(f'✅ Coverage ({coverage:.1f}%) meets minimum threshold ({min_coverage}%)')
           "
 
       - name: Upload coverage report

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]  # or your default branch
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -48,6 +52,8 @@ jobs:
 
     - name: Compare coverage (soft-block on regression)
       uses: ewjoachim/python-coverage-comment-action@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # crucial for auth
       with:
         coverage-file: coverage.xml
         minimum-coverage: 98  # Optional threshold

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       SHOPIFY_FIXED_ARGS: ${{ secrets.SHOPIFY_FIXED_ARGS }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      MIN_COVERAGE_THRESHOLD: '98'
+      MIN_COVERAGE_THRESHOLD: '97'
 
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
               print(f'Coverage: {coverage:.1f}%')
               
               # Get minimum coverage threshold from environment variable
-              min_coverage = float(os.environ.get('MIN_COVERAGE_THRESHOLD', '98'))
+              min_coverage = float(os.environ.get('MIN_COVERAGE_THRESHOLD', '97'))
               print(f'Minimum coverage threshold: {min_coverage}%')
               
               if coverage < min_coverage:
@@ -76,5 +76,5 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          MINIMUM_GREEN: 98
+          MINIMUM_GREEN: 97
           MINIMUM_ORANGE: 70

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,46 +2,50 @@ name: Test Coverage Check
 
 on:
   pull_request:
+    types: [labeled]
 
 jobs:
-  coverage:
+  test-resources:
+    # Only run on PRs targeting main labeled with 'run-coverage-tests'
+    if: github.base_ref == 'main' && github.event.label.name == 'run-coverage-tests'
     runs-on: ubuntu-latest
+    env:
+      SHOPIFY_FIXED_ARGS: ${{ secrets.SHOPIFY_FIXED_ARGS }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2  # allow diffing with base commit
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[milvus,shopify,hubspot]' --quiet
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[milvus,shopify,hubspot]' --quiet
 
-    - name: Test with pytest
-      run: |
-        pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=html --no-cov-on-fail
+      - name: Test with pytest
+        run: |
+          pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=html --no-cov-on-fail
 
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-report
-        path: coverage.xml
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
 
-    - name: Upload HTML coverage report
-      uses: actions/upload-artifact@v4
-      with:
-        name: htmlcov
-        path: htmlcov/
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: htmlcov
+          path: htmlcov/
 
-    - name: Display coverage
-      uses: py-cov-action/python-coverage-comment-action@v3
-      with:
-        GITHUB_TOKEN: ${{ github.token }}
-        MINIMUM_GREEN: 98
-        MINIMUM_ORANGE: 70
+      - name: Display coverage
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          MINIMUM_GREEN: 98
+          MINIMUM_ORANGE: 70

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,11 +2,6 @@ name: Test Coverage Check
 
 on:
   pull_request:
-    branches: [main]  # or your default branch
-
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
   coverage:
@@ -18,19 +13,19 @@ jobs:
       with:
         fetch-depth: 2  # allow diffing with base commit
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e '.[milvus,shopify,hubspot]' --quiet
 
-    - name: Run tests and collect coverage
+    - name: Test with pytest
       run: |
-        pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=xml --cov-report=html --no-cov-on-fail
+        pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=html --no-cov-on-fail
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     branches: [main]  # or your default branch
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
     - name: Checkout code
@@ -25,17 +26,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov
-        pip install -e .
+        pip install -e '.[milvus,shopify,hubspot]' --quiet
 
     - name: Run tests and collect coverage
       run: |
-        pytest tests/ \
-          --cov=arklex \
-          --cov-report=term \
-          --cov-report=xml \
-          --cov-report=html \
-          --no-cov-on-fail
+        pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=xml --cov-report=html --no-cov-on-fail
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       SHOPIFY_FIXED_ARGS: ${{ secrets.SHOPIFY_FIXED_ARGS }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      MIN_COVERAGE_THRESHOLD: '95'
 
     steps:
       - name: Checkout
@@ -29,7 +30,38 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=html --no-cov-on-fail
+          pytest tests/ --cov=arklex --cov-report=term-missing --cov-report=html --cov-report=xml --no-cov-on-fail
+
+      - name: Check coverage threshold
+        run: |
+          # Install coverage tool if not already installed
+          pip install coverage
+          
+          # Generate coverage report and extract total coverage
+          coverage run -m pytest tests/ --no-cov-on-fail
+          coverage xml
+          
+          # Extract coverage percentage from XML using Python
+          python -c "
+          import xml.etree.ElementTree as ET
+          import os
+          
+          tree = ET.parse('coverage.xml')
+          root = tree.getroot()
+          coverage = float(root.attrib['line-rate']) * 100
+          print(f'Coverage: {coverage:.1f}%')
+          
+          # Get minimum coverage threshold from environment variable
+          min_coverage = float(os.environ.get('MIN_COVERAGE_THRESHOLD', '95'))
+          print(f'Minimum coverage threshold: {min_coverage}%')
+          
+          if coverage < min_coverage:
+              print(f'❌ Coverage ({coverage:.1f}%) is below minimum threshold ({min_coverage}%)')
+              print('This PR will be blocked until coverage is improved.')
+              exit(1)
+          else:
+              print(f'✅ Coverage ({coverage:.1f}%) meets minimum threshold ({min_coverage}%)')
+          "
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,56 @@
+name: Test Coverage Check
+
+on:
+  pull_request:
+    branches: [main]  # or your default branch
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2  # allow diffing with base commit
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov
+        pip install -e .
+
+    - name: Run tests and collect coverage
+      run: |
+        pytest tests/ \
+          --cov=arklex \
+          --cov-report=term \
+          --cov-report=xml \
+          --cov-report=html \
+          --no-cov-on-fail
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage.xml
+
+    - name: Upload HTML coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: htmlcov
+        path: htmlcov/
+
+    - name: Compare coverage (soft-block on regression)
+      uses: ewjoachim/python-coverage-comment-action@v3
+      with:
+        coverage-file: coverage.xml
+        minimum-coverage: 98  # Optional threshold
+        hide-comment: false  # Ensures the comment is visible
+        fail-on-coverage-decrease: false  # Set to true to block merges
+        post-new-comment: true  # Forces a new comment per PR update

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,13 +4,12 @@ on:
   pull_request:
     branches: [main]  # or your default branch
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
     - name: Checkout code
@@ -50,13 +49,9 @@ jobs:
         name: htmlcov
         path: htmlcov/
 
-    - name: Compare coverage (soft-block on regression)
-      uses: ewjoachim/python-coverage-comment-action@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # crucial for auth
+    - name: Display coverage
+      uses: py-cov-action/python-coverage-comment-action@v3
       with:
-        coverage-file: coverage.xml
-        minimum-coverage: 98  # Optional threshold
-        hide-comment: false  # Ensures the comment is visible
-        fail-on-coverage-decrease: false  # Set to true to block merges
-        post-new-comment: true  # Forces a new comment per PR update
+        GITHUB_TOKEN: ${{ github.token }}
+        MINIMUM_GREEN: 98
+        MINIMUM_ORANGE: 70

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,10 +5,17 @@ on:
     types: [labeled]
 
 jobs:
-  test-resources:
-    # Only run on PRs targeting main labeled with 'run-coverage-tests'
+  test:
+    name: run tests and display coverage
+
     if: github.base_ref == 'main' && github.event.label.name == 'run-coverage-tests'
+
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
     env:
       SHOPIFY_FIXED_ARGS: ${{ secrets.SHOPIFY_FIXED_ARGS }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,3 +172,6 @@ line-ending = "auto"
 docstring-code-format = false
 
 docstring-code-line-length = "dynamic"
+
+[tool.coverage.run]
+relative_files = true


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- Add a GitHub Actions workflow to run tests with coverage reporting on pull requests targeting the main branch.
- Implement soft-blocking on coverage regression by posting PR comments if coverage drops below 98%.
- Upload coverage XML and HTML reports as workflow artifacts for review.

## Description
<!-- Provide detailed information about the changes -->
- This change is needed to ensure that test coverage does not regress unnoticed during development and pull requests.
- It solves the problem by automatically running pytest with coverage, comparing coverage against thresholds, and alerting developers via PR comments.
- Coverage reports are also uploaded as artifacts for deeper inspection when needed.
- 
- How does this change solve the problem?
- What side effects might this change have?


## Tests
<!-- How did you verify these changes? -->
- [x] This workflow is tested thoroughly with both positive (https://github.com/arklexai/Agent-First-Organization/actions/runs/15924795798/job/44919522222) and negative (https://github.com/arklexai/Agent-First-Organization/actions/runs/15924698592/job/44919215077) case!


## Reviewers
<!-- Mention the reviewers for this PR -->
- TBD