### PR TITLE
feat: update test coverage threshold to 98.

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       SHOPIFY_FIXED_ARGS: ${{ secrets.SHOPIFY_FIXED_ARGS }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      MIN_COVERAGE_THRESHOLD: '97'
+      MIN_COVERAGE_THRESHOLD: '98'
 
     steps:
       - name: Checkout
@@ -52,7 +52,7 @@ jobs:
               print(f'Coverage: {coverage:.1f}%')
               
               # Get minimum coverage threshold from environment variable
-              min_coverage = float(os.environ.get('MIN_COVERAGE_THRESHOLD', '97'))
+              min_coverage = float(os.environ.get('MIN_COVERAGE_THRESHOLD', '98'))
               print(f'Minimum coverage threshold: {min_coverage}%')
               
               if coverage < min_coverage:
@@ -83,5 +83,5 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          MINIMUM_GREEN: 97
+          MINIMUM_GREEN: 98
           MINIMUM_ORANGE: 70


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- Implement blocking on coverage regression by posting PR comments if coverage drops below 99%.
- This is OK since you can pick `regression-test` label if you do not care about the test coverage.

## Description
<!-- Provide detailed information about the changes -->
- This change is needed to ensure that test coverage does not regress unnoticed during development and pull requests.


## Tests
<!-- How did you verify these changes? -->
- [x] Since the test coverage is right now 98.5%, it is OK to increase the threshold to 98%, which is rounded-down.


## Reviewers
<!-- Mention the reviewers for this PR -->
- TBD