### PR TITLE
Fix the issue of slotfilling (does not consider values in enum before)

### DIFF
--- a/arklex/env/tools/hubspot/check_availability.py
+++ b/arklex/env/tools/hubspot/check_availability.py
@@ -51,7 +51,7 @@ outputs: list[dict[str, Any]] = [
     {
         "name": "meeting_info",
         "type": "dict",
-        "decription": "The time and date of the meeting if available. If not, the function will return a list of available time slots to choose from. If no time slots are available, the function will say no times available.",
+        "description": "The time and date of the meeting if available. If not, the function will return a list of available time slots to choose from. If no time slots are available, the function will say no times available.",
     }
 ]
 

--- a/arklex/orchestrator/NLU/utils/formatters.py
+++ b/arklex/orchestrator/NLU/utils/formatters.py
@@ -31,6 +31,8 @@ def _format_slot_description(slot: Slot) -> str:
         description += " (required)"
     if slot.type:
         description += f" (type: {slot.type})"
+    if slot.enum:
+        description += f" (enum: {slot.enum})"
     return description
 
 
@@ -188,6 +190,7 @@ def format_verification_input(slot: dict[str, Any], chat_history_str: str) -> st
             - description: Slot description
             - value: Current slot value
             - type: Slot value type
+            - enum: Fixed choice of value for the slot
         chat_history_str: Formatted chat history providing conversation context
 
     Returns:
@@ -204,6 +207,7 @@ Slot:
 - Description: {slot["description"]}
 - Value: {slot.get("value", "Not provided")}
 - Type: {slot.get("type", "Not specified")}
+- Enum: {slot.get("enum", "Not provided")}
 
 Chat History:
 {chat_history_str}


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- I modified a little in formatter files to make sure every function of hubspot works well. And I found the slotfilling seems to fail.


## Description
<!-- Provide detailed information about the changes -->
- Ensure every functions work is essential. 
- Add enum in the context for slotfilling api to consider


## Tests
<!-- How did you verify these changes? -->
- I just ensure the previous problematic function works. And it does consider enum value of the slots now.

## Note
- I want to mention that I am not fully aware of how formatter.py works. Currently I only made some changes for the prompt. I cannot guarantee other places to format slot are good.

## Reviewers
<!-- Mention the reviewers for this PR -->
@arklexai/agent-leads