### PR TITLE
cache only the query embedding

### DIFF
--- a/arklex/env/tools/RAG/retrievers/milvus_retriever.py
+++ b/arklex/env/tools/RAG/retrievers/milvus_retriever.py
@@ -132,9 +132,7 @@ class MilvusRetriever:
         )
         quoted_ids = ",".join([f"'{qa_id}'" for qa_id in qa_ids])
         filter_expr = f"id in [{quoted_ids}]"
-        res = self.client.delete(
-            collection_name=collection_name, filter=filter_expr
-        )
+        res = self.client.delete(collection_name=collection_name, filter=filter_expr)
         return res
 
     def delete_documents_by_qa_doc_id(
@@ -352,7 +350,7 @@ class MilvusRetriever:
             tags = {}
 
         partition_key = self.get_bot_uid(bot_id, version)
-        query_embedding = embed(query)
+        query_embedding = embed(query, cache=True)
         filter = f'bot_uid == "{partition_key}"'
         if tags:
             # NOTE: Only support one tag for now

--- a/arklex/env/tools/RAG/retrievers/retriever_document.py
+++ b/arklex/env/tools/RAG/retrievers/retriever_document.py
@@ -36,7 +36,7 @@ def _generate_cache_key(text: str, model: str = "text-embedding-ada-002") -> str
     return f"arklex::embedding::retriever::{model}::{text_hash}"
 
 
-def embed(text: str) -> list[float]:
+def embed(text: str, cache: bool = False) -> list[float]:
     """Generate embeddings for text with Redis caching."""
 
     cache_key = _generate_cache_key(text)
@@ -56,12 +56,13 @@ def embed(text: str) -> list[float]:
         response = client.embeddings.create(input=text, model="text-embedding-ada-002")
         embedding = response.data[0].embedding
 
-        # Cache the embedding
-        try:
-            redis_pool.set(cache_key, embedding, ttl=EMBEDDING_CACHE_TTL)
-            log_context.info(f"Cached embedding for text of length {len(text)}")
-        except Exception as e:
-            log_context.warning(f"Redis cache write error: {e}")
+        if cache:
+            # Cache the embedding
+            try:
+                redis_pool.set(cache_key, embedding, ttl=EMBEDDING_CACHE_TTL)
+                log_context.info(f"Cached embedding for text of length {len(text)}")
+            except Exception as e:
+                log_context.warning(f"Redis cache write error: {e}")
 
         return embedding
 

--- a/tests/env/tools/RAG/test_retriever_document.py
+++ b/tests/env/tools/RAG/test_retriever_document.py
@@ -42,7 +42,7 @@ class TestEmbedFunction:
         mock_client.embeddings.create.return_value = mock_response
         mock_openai_class.return_value = mock_client
 
-        result = embed("test text")
+        result = embed("test text", cache=True)
 
         assert result == [0.1, 0.2, 0.3]
         mock_client.embeddings.create.assert_called_once_with(
@@ -62,7 +62,7 @@ class TestEmbedFunction:
         cached_embedding = [0.1, 0.2, 0.3]
         mock_redis_pool.get.return_value = cached_embedding
 
-        result = embed("test text")
+        result = embed("test text", cache=True)
 
         assert result == cached_embedding
         mock_redis_pool.get.assert_called_once()


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- fixes the issue where documents that were added to the knowledge base were getting cached

## Description
<!-- Provide detailed information about the changes -->
- redis is flooded with document embedding caches
- makes caching of the embedding optional
- no side effects, better control on caching embeddings

## Tests
<!-- How did you verify these changes? -->
- [x] Pre-commit code format check: Run `pip install pre-commit` and `pre-commit install` before committing changes
- [x] Attach one of `run-coverage-tests` label, `run-diff-coverage-tests` label, or `run-integration-tests` label (to skip test coverage) and ensure the check passes.
- [x] Test case 1: ensure that caching happens only during queries
- [x] Test case 2: ensure that caching does not happen when adding documents

## Reviewers
<!-- Mention the reviewers for this PR -->
@arklexai/agent-leads 
@shehan360 
