### PR TITLE
fix nlu based http tool

### DIFF
--- a/arklex/__init__.py
+++ b/arklex/__init__.py
@@ -15,4 +15,4 @@ Key Components:
 For more information, visit: https://github.com/Agent-First-Organization/Arklex
 """
 
-__version__ = "0.0.20-rc.1"
+__version__ = "0.0.20-rc.2"

--- a/arklex/env/env.py
+++ b/arklex/env/env.py
@@ -138,9 +138,11 @@ class DefaultResourceInitializer(BaseResourceInitializer):
                     tool_instance.load_slots(all_slots)
                     tool_instance.fixed_args.update(node_specific_data.get("http", {}))
                     tool_instance.description = attributes.get("task", "")
-                    tool_instance.name = node_specific_data.get(
-                        "name", attributes.get("task", "").replace(" ", "_").lower()
-                    )
+                    tool_instance.name = node_specific_data.get("name", "")
+                    if tool_instance.name == "":
+                        tool_instance.name = tool_instance.description.replace(
+                            " ", "_"
+                        ).lower()
                     tool_id = tool_instance.name
                 tool_registry[tool_id] = {
                     "name": f"{path.replace('/', '-')}-{name}",

--- a/arklex/orchestrator/orchestrator.py
+++ b/arklex/orchestrator/orchestrator.py
@@ -444,8 +444,17 @@ Answer with only 'yes' or 'no'"""
         message_state.message_queue = message_queue
 
         response_state: MessageState
+        resource_id = node_info.resource_id
+        if resource_id == "http_tool":
+            resource_id = node_info.attributes.get("node_specific_data", {}).get(
+                "name", ""
+            )
+            if resource_id == "":
+                resource_id = (
+                    node_info.attributes.get("task", "").replace(" ", "_").lower()
+                )
         response_state, params = self.env.step(
-            node_info.resource_id, message_state, params, node_info
+            resource_id, message_state, params, node_info
         )
         params.memory.trajectory = response_state.trajectory
         return node_info, response_state, params


### PR DESCRIPTION
## Summary
This is to fix execution of NLU based http_tool.

## Description
The execution of NLU based http_tool is broken because of resource id mismatch. This PR fixes it.

## Tests
- [x] Pre-commit code format check: Run `pip install pre-commit` and `pre-commit install` before committing changes
- [x] Attach one of `run-coverage-tests` label, `run-diff-coverage-tests` label, or `run-integration-tests` label (to skip test coverage) and ensure the check passes.
- [x] Test case 1: Tested NLU based http_tool
- [x] Test case 2: Tested realtime voice agent

## Reviewers
<!-- Mention the reviewers for this PR -->
@arklexai/agent-leads
