### PR TITLE
Update README to include clone step for running test_api_keys.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ pip install arklex
 # Create .env file
 echo "OPENAI_API_KEY=your_key_here" > .env
 
+# Clone the repository (required if you want to run example/test scripts)
+git clone https://github.com/arklexai/Agent-First-Organization.git
+cd Agent-First-Organization
+pip install -e .
+
 # Test your API keys (recommended)
 python test_api_keys.py
 


### PR DESCRIPTION
## Summary
Clarify in the README that cloning the repo is necessary before running test_api_keys.py or example scripts.

## Description
When I first tried running test_api_keys.py, it wasn't immediately clear that I needed to clone the repository and install it locally via pip install -e ..
This small addition helps first-time users avoid confusion and ensures a smoother setup experience.

## Tests
 Manually verified the README instructions from a clean environment.

 No code changes, so no test cases are required.

## Reviewers
@arklexai/agent-leads