### PR TITLE
agent/tool - slotGroup fix

### DIFF
--- a/arklex/env/agents/openai_agent.py
+++ b/arklex/env/agents/openai_agent.py
@@ -340,7 +340,9 @@ class OpenAIAgent(BaseAgent):
                             and value_source == "fixed"
                         ):
                             group_value = slot.get("value", "")
-                        slot_value = build_slot_values(slot["schema"], group_value)
+                        slot_list = build_slot_values(slot["schema"], group_value)
+                        # Convert list of slot dicts to single object for non-repeatable groups
+                        slot_value = {slot_dict["name"]: slot_dict["value"] for slot_dict in slot_list}
                 else:
                     if value_source == "fixed":
                         slot_value = slot.get("value", "")

--- a/arklex/orchestrator/NLU/entities/slot_entities.py
+++ b/arklex/orchestrator/NLU/entities/slot_entities.py
@@ -56,13 +56,18 @@ class Slot(BaseModel):
     def to_openai_schema(self) -> dict | None:
         if getattr(self, "valueSource", None) == "fixed":
             return None
-        if self.items is not None:
+        
+        def _get_type_map() -> dict[str, str]:
+            """Get the mapping from internal types to OpenAI schema types."""
             return {
-                "type": "array",
-                "items": self.items,
-                "description": getattr(self, "description", ""),
+                "str": "string",
+                "int": "integer",
+                "float": "number",
+                "bool": "boolean",
             }
-        if self.type == "group":
+
+        def _build_group_schema() -> dict:
+            """Build schema for group type fields."""
             properties = {}
             required = []
             for field in self.schema or []:
@@ -72,23 +77,52 @@ class Slot(BaseModel):
                 properties[field_slot.name] = field_slot.to_openai_schema()
                 if getattr(field_slot, "required", False):
                     required.append(field_slot.name)
+            
             return {
                 "type": "object",
                 "properties": properties,
                 "required": required,
                 "description": getattr(self, "description", ""),
             }
+
+        def _build_primitive_schema() -> dict:
+            """Build schema for primitive type fields."""
+            type_map = _get_type_map()
+            return {
+                "type": type_map.get(self.type, "string"),
+                "description": getattr(self, "description", ""),
+            }
+
+        # Handle repeatable fields - they should be arrays
+        if getattr(self, "repeatable", False):
+            if self.type == "group":
+                # For repeatable group, each item is an object with the group's schema
+                return {
+                    "type": "array",
+                    "items": _build_group_schema(),
+                    "description": getattr(self, "description", ""),
+                }
+            else:
+                # For repeatable primitive types, define the item type
+                return {
+                    "type": "array",
+                    "items": _build_primitive_schema(),
+                    "description": getattr(self, "description", ""),
+                }
+        
+        # Handle non-repeatable fields
+        if self.items is not None:
+            return {
+                "type": "array",
+                "items": self.items,
+                "description": getattr(self, "description", ""),
+            }
+        
+        if self.type == "group":
+            return _build_group_schema()
+        
         # Primitive type
-        type_map = {
-            "str": "string",
-            "int": "integer",
-            "float": "number",
-            "bool": "boolean",
-        }
-        return {
-            "type": type_map.get(self.type, "string"),
-            "description": getattr(self, "description", ""),
-        }
+        return _build_primitive_schema()
 
 
 class SlotInput(BaseModel):


### PR DESCRIPTION
## Summary
This is a fix to get SlotGroups working in OpenAI Agent.

## Description
Currently, the openai schema conversion is not working as expected - a single dictionary is getting returned instead of array when the slot is repeatable. This fix aims to fix that.


## Tests

- [x] Test case 1: Primitive Slots - getting filled as expected
- [x] Test case 2: Non repeatable slots - getting filled as expected
- [x] Test case 3: Repeatable slots - getting filled as expected

## Reviewers

