### PR TITLE
Fix/retriever tool auth fix

### DIFF
--- a/arklex/env/agents/openai_agent.py
+++ b/arklex/env/agents/openai_agent.py
@@ -251,21 +251,24 @@ class OpenAIAgent(BaseAgent):
         This method is called during the initialization of the agent.
         """
         for tool_id, (tool, node_info) in self.available_tools.items():
-            tool_object = tool["tool_instance"]
+            tool_instance = tool["tool_instance"]
 
             log_context.info(
-                f"Configuring tool: {tool_object.func.__name__} with slots: {tool_object.slots}"
+                f"Configuring tool: {tool_instance.func.__name__} with slots: {tool_instance.slots}"
             )
-            tool_def = tool_object.to_openai_tool_def_v2()
+            tool_def = tool_instance.to_openai_tool_def_v2()
             tool_def["function"]["name"] = tool_id
             self.tool_defs.append(tool_def)
-            self.tool_slots[tool_id] = tool_object.slots.copy()
-            self.tool_map[tool_id] = tool_object.func
-            combined_args: dict[str, Any] = {
-                **tool["fixed_args"],
-                **(node_info.additional_args or {}),
-            }
+            self.tool_slots[tool_id] = tool_instance.slots.copy()
+            self.tool_map[tool_id] = tool_instance.func
+            combined_args: dict[str, Any] = {}
+            log_context.info(f"Combined args before: {combined_args}")
+            combined_args.update(node_info.additional_args)
+            combined_args.update(tool["fixed_args"])
+            combined_args.update(tool_instance.auth)
+            log_context.info(f"Combined args after: {combined_args}")
             self.tool_args[tool_id] = combined_args
+
         log_context.info(f"Tool Definitions: {self.tool_defs}")
 
     def _execute_tool(

--- a/arklex/env/env.py
+++ b/arklex/env/env.py
@@ -384,7 +384,7 @@ class Environment:
             tool: Tool = self.tools[id]["tool_instance"]
             tool.init_slotfiller(self.slotfillapi)
             combined_args: dict[str, Any] = {
-                **self.tools[id]["fixed_args"],
+                **tool.fixed_args,
                 **tool.auth,
                 **(node_info.additional_args or {}),
             }

--- a/tests/env/agents/test_openai_agent.py
+++ b/tests/env/agents/test_openai_agent.py
@@ -53,13 +53,20 @@ def mock_tools() -> dict:
     tool_func.__name__ = "mock_tool"
     tool_object.func = tool_func
 
-    return {
+    # Configure auth and slots as proper dictionaries
+    tool_object.auth = {}
+    tool_object.slots = []
+
+    # Create a proper dictionary structure
+    tools_dict = {
         "mock_tool_id": {
             "tool_instance": tool_object,
             "execute": lambda: tool_object,
             "fixed_args": {"fixed_param": "value"},
         }
     }
+
+    return tools_dict
 
 
 @pytest.fixture
@@ -83,7 +90,7 @@ class TestOpenAIAgent:
         mock_trace: Mock,
         mock_load_prompts: Mock,
         mock_state: Mock,
-        mock_tools: Mock,
+        mock_tools: dict,
         mock_nodes: Mock,
     ) -> None:
         """Test OpenAIAgent initialization."""
@@ -172,7 +179,7 @@ class TestOpenAIAgent:
         mock_json_dumps: Mock,
         mock_trace: Mock,
         mock_state: Mock,
-        mock_tools: Mock,
+        mock_tools: dict,
     ) -> None:
         """Test generate method with tool calls."""
         mock_json_dumps.return_value = '{"result": "success"}'
@@ -384,7 +391,7 @@ class TestOpenAIAgent:
         assert isinstance(result, dict)
 
     def test_load_tools(
-        self, mock_state: Mock, mock_tools: Mock, mock_nodes: Mock
+        self, mock_state: Mock, mock_tools: dict, mock_nodes: Mock
     ) -> None:
         """Test _load_tools method."""
         agent = OpenAIAgent(
@@ -424,7 +431,7 @@ class TestOpenAIAgent:
         # Test that non-existent tool is not loaded
         assert "nonexistent_tool" not in agent.available_tools
 
-    def test_configure_tools(self, mock_state: Mock, mock_tools: Mock) -> None:
+    def test_configure_tools(self, mock_state: Mock, mock_tools: dict) -> None:
         """Test _configure_tools method."""
         agent = OpenAIAgent(
             successors=[],
@@ -437,7 +444,9 @@ class TestOpenAIAgent:
         mock_node = Mock()
         mock_node.attributes = {}
         mock_node.additional_args = {}
-        agent.available_tools["test_tool_id"] = (mock_tools["mock_tool_id"], mock_node)
+        # Get the tool from the mock_tools using the dictionary access
+        tool_data = mock_tools["mock_tool_id"]
+        agent.available_tools["test_tool_id"] = (tool_data, mock_node)
         agent._configure_tools()
 
         assert "test_tool_id" in agent.tool_map


### PR DESCRIPTION
## Summary
<!-- What is this PR about? Provide a clear, concise summary -->
- This PR fixes the retriever tool's execution

## Description
<!-- Provide detailed information about the changes -->
- The name of the collection that needs to be retrieved has been moved from the `fixed_args` field to the `auth` field. 
- Added the auth data to the tool 

## Tests
<!-- How did you verify these changes? -->
- [x] Pre-commit code format check: Run `pip install pre-commit` and `pre-commit install` before committing changes
- [x] Attach one of `run-coverage-tests` label, `run-diff-coverage-tests` label, or `run-integration-tests` label (to skip test coverage) and ensure the check passes.
- [x] Test case 1: Manually test the retriever
- [x] Test case 2: Fix tests that tested the retriever

## Reviewers
<!-- Mention the reviewers for this PR -->
@arklexai/agent-leads
