### PR TITLE
api, tool: id check fix

### DIFF
--- a/arklex/env/env.py
+++ b/arklex/env/env.py
@@ -303,7 +303,7 @@ class Environment:
             Tuple containing updated message state and parameters
         """
         node_response: NodeResponse
-        if id in self.tools:
+        if id in self.tools or id == ToolItem.HTTP_TOOL:
             if id == ToolItem.HTTP_TOOL:
                 log_context.info(f"HTTP tool {node_info.data.get('name', '')} selected")
                 tool: Tool = self.tools[node_info.data.get("name", "")]["tool_instance"]


### PR DESCRIPTION
## Summary
The http tool was not being correctly identified after recent refactor changes. The issue was caused by reliance on the task name rather than the intended identifier. This update corrects the identification mechanism so that the http tool is properly recognized and can be invoked as expected.

## Description
The http tool was not being correctly identified after recent refactor changes. The issue was caused by reliance on the task name rather than the intended identifier. This update corrects the identification mechanism so that the http tool is properly recognized and can be invoked as expected.

There was an issue with a check in particular and it has been sorted

## Tests
<!-- How did you verify these changes? -->
- [x] Test Case 1: Http tool executes as expected
- [x] Test Case 2: The slot filling of the http tool works as expected

## Reviewers
<!-- Mention the reviewers for this PR -->
@arklexai/agent-leads
