### PR TITLE
add output to avoid error log in twilio/calls/transfer

### DIFF
--- a/arklex/env/tools/twilio/calls/transfer.py
+++ b/arklex/env/tools/twilio/calls/transfer.py
@@ -60,7 +60,9 @@ def transfer(**kwargs: TransferCallKwargs) -> str:
         call.update(twiml=str(response))
 
         log_context.info("Call transfer completed successfully.")
+        return "Call transfer completed successfully."
 
     except Exception as e:
         log_context.error(f"Error executing call transfer: {e}")
         log_context.exception(e)
+        return "Call transfer failed."


### PR DESCRIPTION
## Summary
Add an output string to twilio/calls/transfer tool

## Description
add output string to avoid error log in twilio/calls/transfer

## Tests
<!-- How did you verify these changes? -->
- [x] Pre-commit code format check: Run `pip install pre-commit` and `pre-commit install` before committing changes
- [x] Attach one of `run-coverage-tests` label, `run-diff-coverage-tests` label, or `run-integration-tests` label (to skip test coverage) and ensure the check passes.
- [x] Test case 1: Tested locally by transferring to xinyang

## Reviewers
@xinyang-articulate 
