### PR TITLE
add case for no agent in task graph

### DIFF
--- a/arklex/orchestrator/task_graph/task_graph.py
+++ b/arklex/orchestrator/task_graph/task_graph.py
@@ -277,6 +277,9 @@ class AgentGraph(TaskGraphBase):
             ]
 
         if start_agent_name is None:
+            if len(self.agents_sdk_agents) == 0:
+                log_context.info("No agents-sdk agents found in the graph")
+                return
             start_agent_name = list(self.agents_sdk_agents.keys())[0]
             start_agent_config = agent_node_specific_data[start_agent_name]
         log_context.info(f"agent handovers: {agent_handovers}")


### PR DESCRIPTION
## Summary
Fix an issue where an error is thrown when there is no realtime voice agent in the task graph.

## Tests
<!-- How did you verify these changes? -->
- [ ] Pre-commit code format check: Run `pip install pre-commit` and `pre-commit install` before committing changes
- [ ] Attach one of `run-coverage-tests` label, `run-diff-coverage-tests` label, or `run-integration-tests` label (to skip test coverage) and ensure the check passes.
- [ ] Test case 1: tested creating a new agent
- [ ] Test case 2: tested existing agent

## Reviewers
@xinyang-articulate 
