### PR TITLE
api, tool: feature/one call slot fill

### DIFF
--- a/arklex/env/tools/tools.py
+++ b/arklex/env/tools/tools.py
@@ -352,8 +352,6 @@ class Tool:
             List of filled slots
         """
         filled_slots = []
-        # for slot in slots:
-            # Use slotfiller directly with the slot - it handles the slot_schema internally
         if slots:
             filled = self.slotfiller.fill_slots(slots, chat_history_str, self.llm_config) # filled is a list of slots
             for i, slot in enumerate(slots):

--- a/arklex/env/tools/tools.py
+++ b/arklex/env/tools/tools.py
@@ -352,11 +352,13 @@ class Tool:
             List of filled slots
         """
         filled_slots = []
-        for slot in slots:
+        # for slot in slots:
             # Use slotfiller directly with the slot - it handles the slot_schema internally
-            filled = self.slotfiller.fill_slots([slot], chat_history_str, self.llm_config)
-            slot.value = self._convert_value(filled[0].value, slot.type)
-            filled_slots.append(slot)
+        if slots:
+            filled = self.slotfiller.fill_slots(slots, chat_history_str, self.llm_config) # filled is a list of slots
+            for i, slot in enumerate(slots):
+                slot.value = self._convert_value(filled[i].value, slot.type) # we need to handle the case where all indexes are filled
+                filled_slots.append(slot)
         return filled_slots
     
 

--- a/arklex/orchestrator/NLU/core/slot.py
+++ b/arklex/orchestrator/NLU/core/slot.py
@@ -80,37 +80,38 @@ class SlotFiller(BaseSlotFilling):
         )
 
     def _slots_to_openai_schema(self, slots: list[Slot]) -> dict[str, Any]:
-        """Convert list of Slot objects to OpenAI JSON schema format using the new slot_schema structure.
-        
-        Args:
-            slots: List of Slot objects to convert
+        """Convert a list of Slot objects into a single OpenAI JSON schema.
 
-        Returns:
-            OpenAI JSON schema dictionary
+        The returned schema is always a top-level object where each slot is a
+        property whose value is that slot's own schema definition.
+
+        Preference order per slot:
+        1) slot.slot_schema (deep-copied and sanitized), else
+        2) slot.to_openai_schema().
         """
         import copy
-        
-        # If we have a single slot with slot_schema, use it directly
-        if len(slots) == 1 and slots[0].slot_schema:
-            slot = slots[0]
-            # Deep copy the slot_schema to avoid modifying the original
-            schema_copy = copy.deepcopy(slot.slot_schema)
-            
-            # Remove non-OpenAI standard fields from the schema
-            self._remove_non_openai_fields(schema_copy)
-            
-            return schema_copy
-        
-        # Fallback to the original method for multiple slots or slots without slot_schema
-        properties = {}
-        required = []
+
+        properties: dict[str, Any] = {}
+        required: list[str] = []
 
         for slot in slots:
-            # Use the to_openai_schema method from the Slot class
-            slot_schema = slot.to_openai_schema()
+            # Prefer explicit slot_schema if provided
+            if getattr(slot, "slot_schema", None):
+                slot_schema = copy.deepcopy(slot.slot_schema)
+                # Unwrap legacy function wrapper to plain JSON Schema parameters if present
+                if isinstance(slot_schema, dict) and "function" in slot_schema:
+                    params = slot_schema.get("function", {}).get("parameters")
+                    if isinstance(params, dict):
+                        slot_schema = params
+                # Sanitize custom fields to adhere to OpenAI JSON schema
+                self._remove_non_openai_fields(slot_schema)
+            else:
+                # Fall back to the legacy per-slot schema generator
+                slot_schema = slot.to_openai_schema()
 
             if slot_schema is None:
-                continue  # Skip slots that return None (like fixed value slots)
+                # Skip slots that explicitly indicate no schema (e.g., fixed values)
+                continue
 
             properties[slot.name] = slot_schema
 
@@ -186,7 +187,7 @@ class SlotFiller(BaseSlotFilling):
             },
         )
 
-        # Generate OpenAI schema from slots
+        # Generate OpenAI schema from slots (let LLM handle descriptions/prompts)
         schema = self._slots_to_openai_schema(slots)
         log_context.info(
             "OpenAI schema generated",
@@ -213,10 +214,14 @@ class SlotFiller(BaseSlotFilling):
         # Process response
         try:
             filled_slots = self.model_service.process_slot_response(response, slots)
-            
-            # If we used the new slot_schema structure, evaluate and fill back default/fixed values
-            if len(slots) == 1 and slots[0].slot_schema:
-                filled_slots = self._evaluate_and_fill_slot_values(filled_slots, slots[0])
+
+            # Apply default/fixed values for any slots that use slot_schema
+            if slots:
+                schema_slots = [s for s in slots if getattr(s, "slot_schema", None)]
+                for schema_slot in schema_slots:
+                    filled_slots = self._evaluate_and_fill_slot_values(
+                        filled_slots, schema_slot
+                    )
             
             log_context.info(
                 "Slot filling completed",

--- a/arklex/orchestrator/NLU/services/model_service.py
+++ b/arklex/orchestrator/NLU/services/model_service.py
@@ -255,13 +255,6 @@ class ModelService:
                     setattr(s, "value", value.get(slot_name))
             return slots
 
-        # Single-slot case: assign value back to the slot object for compatibility
-        slot = slots[0]
-        if isinstance(extracted_values, dict):
-            slot.value = extracted_values.get(slot.name, None)
-        else:
-            slot.value = extracted_values
-
         return slots
 
     def _process_traditional_slot_response(

--- a/arklex/orchestrator/NLU/services/model_service.py
+++ b/arklex/orchestrator/NLU/services/model_service.py
@@ -195,6 +195,9 @@ class ModelService:
             ValueError: If response parsing fails
         """
         try:
+            # If there are no slots to process, return empty list early
+            if not slots:
+                return []
             # Handle both string and dict responses
             if isinstance(response, str):
                 # Parse the JSON response if it's a string
@@ -205,12 +208,11 @@ class ModelService:
             else:
                 raise ValueError(f"Unsupported response type: {type(response)}")
 
-            # Check if we're dealing with a slot_schema structure
-            if (
-                len(slots) == 1
-                and hasattr(slots[0], "slot_schema")
-                and slots[0].slot_schema
-            ):
+            # Route to slot_schema handler if ANY slot provides a slot_schema
+            has_any_slot_schema = any(
+                getattr(s, "slot_schema", None) for s in slots
+            )
+            if has_any_slot_schema:
                 # Handle new slot_schema structure
                 return self._process_slot_schema_response(extracted_values, slots)
             else:
@@ -238,12 +240,27 @@ class ModelService:
         Returns:
             Updated list of slots with extracted values
         """
-        slot = slots[0]
+        # If we received a merged object and have one or more slots, set each
+        # slot object's value to {slot_name: value} and return the original
+        # list of slots. This preserves downstream expectations of slot objects.
+        if isinstance(extracted_values, dict) and len(slots) >= 1:
+            for s in slots:
+                slot_name = s.get("name") if isinstance(s, dict) else getattr(s, "name", None)
+                if not slot_name:
+                    continue
+                value = extracted_values.get(slot_name)
+                if isinstance(s, dict):
+                    s["value"] = value.get(slot_name)
+                else:
+                    setattr(s, "value", value.get(slot_name))
+            return slots
 
-        # Extract values from the nested schema structure
-        # The response should match the structure defined in slot_schema
+        # Single-slot case: assign value back to the slot object for compatibility
+        slot = slots[0]
         if isinstance(extracted_values, dict):
             slot.value = extracted_values.get(slot.name, None)
+        else:
+            slot.value = extracted_values
 
         return slots
 

--- a/arklex/orchestrator/NLU/services/model_service.py
+++ b/arklex/orchestrator/NLU/services/model_service.py
@@ -250,7 +250,7 @@ class ModelService:
                 if isinstance(s, dict):
                     s["value"] = value.get(slot_name)
                 else:
-                    setattr(s, "value", value.get(slot_name))
+                    s.value = value.get(slot_name)
             return slots
 
         return slots

--- a/arklex/orchestrator/NLU/services/model_service.py
+++ b/arklex/orchestrator/NLU/services/model_service.py
@@ -240,9 +240,7 @@ class ModelService:
         Returns:
             Updated list of slots with extracted values
         """
-        # If we received a merged object and have one or more slots, set each
-        # slot object's value to {slot_name: value} and return the original
-        # list of slots. This preserves downstream expectations of slot objects.
+
         if isinstance(extracted_values, dict) and len(slots) >= 1:
             for s in slots:
                 slot_name = s.get("name") if isinstance(s, dict) else getattr(s, "name", None)


### PR DESCRIPTION
## Summary
This PR modifies the slot filling system to combine all slots into a single schema and make one LLM call instead of processing slots individually, improving efficiency

## Description
Previously, slots were being processed individually, requiring multiple LLM calls. This was inefficient and didn't allow the LLM to see relationships between different slots. The system needed to be optimized to process all slots in a single batch operation.


## Tests

- [X] Test case 1: Verify that multiple slots are filled in a single LLM call
- [X] Test case 2: Confirm that slot values are properly normalized to single-key dictionaries
- [X] Test case 3: Test slot filling with various slot types to ensure batch processing works correctly

## Reviewers
@arklexai/agent-leads
