### PR TITLE
[AGML-85] fix for check skip node

### DIFF
--- a/arklex/orchestrator/orchestrator.py
+++ b/arklex/orchestrator/orchestrator.py
@@ -254,13 +254,11 @@ Answer with only 'yes' or 'no'"""
         log_context.info(f"prompt for check skip node: {prompt}")
 
         try:
-            response = self.llm.invoke(prompt)
-            log_context.info(f"LLM response for task verification: {response}")
-            response_text = (
-                response.content.lower().strip()
-                if hasattr(response, "content")
-                else str(response).lower().strip()
+            response_text = self.model_service.get_response(prompt)
+            log_context.info(
+                f"LLM response for task verification: {response_text}"
             )
+            response_text = str(response_text).lower().strip()
             return response_text == "yes"
         except Exception as e:
             log_context.error(f"Error in LLM task verification: {str(e)}")


### PR DESCRIPTION
## Summary
Ensures orchestrator uses the centralized model initialization/config (LLMConfig via ModelService). Fixes runtime error “self.llm doesn’t exist” and aligns LLM usage with project patterns.

## Description
self.llm was never initialized in AgentOrg, causing a runtime error during check_skip_node functionality; this change replaces self.llm.invoke(prompt) with self.model_service.get_response(prompt), leveraging the existing, centrally configured ModelService that respects LLMConfig to invoke the LLM consistently.

## Tests
- [X] Test case 1: Verify whether the node was skipped with can_skip was checked
- [X] Test case 2: Verify whether the node was skipped with can_skip was checked

## Reviewers
@arklexai/agent-leads
