### PR TITLE
feat(hub): PLA-100: add model selection for all agents

### DIFF
--- a/arklex/orchestrator/orchestrator.py
+++ b/arklex/orchestrator/orchestrator.py
@@ -112,7 +112,6 @@ class AgentOrg:
         message_queue: janus.Queue | None = None,
     ) -> OrchestratorResp:
         nlu_agent = self.agents[AgentItem.NLU_AGENT]["agent_instance"](
-            self.llm_config,
             self.nlu_graph,
             self.executor,
             guardrail_llm_config=self.guardrail_llm_config,

--- a/arklex/orchestrator/task_graph/agent_graph.py
+++ b/arklex/orchestrator/task_graph/agent_graph.py
@@ -193,7 +193,7 @@ class AgentGraph(GraphBase):
                     "instructions": prompt,
                     "tools": agents_tools,
                     "handoff_description": agent_data.handoff_description,
-                    "model": self.model,
+                    "model": agent_data.model or self.model,
                 }
                 if self.model_settings is not None:
                     agent_kwargs["model_settings"] = self.model_settings
@@ -378,5 +378,6 @@ class RealtimeAgentGraph(GraphBase):
             speed=start_agent_data.speed,
             turn_detection=start_agent_data.turn_detection,
             voicemail_tool=voicemail_tool,
+            model=start_agent_data.model,
         )
         self.start_agent.response_played = response_played_event

--- a/arklex/orchestrator/task_graph/nlu_graph.py
+++ b/arklex/orchestrator/task_graph/nlu_graph.py
@@ -56,6 +56,12 @@ class NLUGraph(GraphBase):
         }
         model_service = ModelService(llm_config)
         self.intent_detector: IntentDetector = IntentDetector(model_service)
+        self.llm_config = llm_config
+    
+    def update_llm_config(self, new_config: LLMConfig) -> None:
+        self.llm_config = new_config
+        model_service = ModelService(self.llm_config)
+        self.intent_detector = IntentDetector(model_service)
 
     def get_pred_intents(self) -> collections.defaultdict[str, list[dict[str, Any]]]:
         intents: collections.defaultdict[str, list[dict[str, Any]]] = (

--- a/arklex/orchestrator/task_graph/nlu_graph.py
+++ b/arklex/orchestrator/task_graph/nlu_graph.py
@@ -42,6 +42,9 @@ class NLUGraph(GraphBase):
         )  # global intents
         self.agent_node: NodeInfo = self.get_agent_node()
         log_context.info(f"agent_node: {self.agent_node}")
+        agent_model = self.agent_node.data.get("model")
+        if agent_model:
+            llm_config = llm_config.model_copy(update={"model_type_or_path": agent_model})
         self.start_node: str = self.get_start_node()
         self.unsure_intent: dict[str, Any] = {
             "intent": "others",
@@ -58,11 +61,6 @@ class NLUGraph(GraphBase):
         self.intent_detector: IntentDetector = IntentDetector(model_service)
         self.llm_config = llm_config
     
-    def update_llm_config(self, new_config: LLMConfig) -> None:
-        self.llm_config = new_config
-        model_service = ModelService(self.llm_config)
-        self.intent_detector = IntentDetector(model_service)
-
     def get_pred_intents(self) -> collections.defaultdict[str, list[dict[str, Any]]]:
         intents: collections.defaultdict[str, list[dict[str, Any]]] = (
             collections.defaultdict(list)

--- a/arklex/resources/agents/llm_based_agent/openai_agent.py
+++ b/arklex/resources/agents/llm_based_agent/openai_agent.py
@@ -39,6 +39,7 @@ class OpenAIAgentData(BaseModel):
     agent_start_message: str | None = None
     handoff_description: str | None = None
     safety_response: str | None = None
+    model: str | None = None
 
 
 class OpenAIAgentOutput(BaseModel):

--- a/arklex/resources/agents/realtime_voice_agent/openai_realtime_agent.py
+++ b/arklex/resources/agents/realtime_voice_agent/openai_realtime_agent.py
@@ -84,7 +84,7 @@ class OpenAIRealtimeAgentData(BaseModel):
     transcription_language: str | None = None
     speed: float = 1.0
     turn_detection: TurnDetection | None = None
-    model: str | None = None
+    model: str = "gpt-realtime-1.5"
 
 
 @register_agent

--- a/arklex/resources/agents/realtime_voice_agent/openai_realtime_agent.py
+++ b/arklex/resources/agents/realtime_voice_agent/openai_realtime_agent.py
@@ -84,6 +84,7 @@ class OpenAIRealtimeAgentData(BaseModel):
     transcription_language: str | None = None
     speed: float = 1.0
     turn_detection: TurnDetection | None = None
+    model: str | None = None
 
 
 @register_agent
@@ -105,6 +106,7 @@ class OpenAIRealtimeAgent(BaseAgent):
         speed: float = 1.0,
         turn_detection: TurnDetection | None = None,
         voicemail_tool: Tool | None = None,
+        model: str = "gpt-realtime-1.5",
     ) -> None:
         """
         Initialize the OpenAI Realtime Agent.
@@ -134,6 +136,7 @@ class OpenAIRealtimeAgent(BaseAgent):
         self.transcript = []
         self.transcript_available: asyncio.Event = asyncio.Event()
         self.call_sid = None
+        self.model = model
         # this event is used to signal that the audio response has finished playing through twilio
         self.response_played: threading.Event = threading.Event()
         self.transcription_language = transcription_language
@@ -194,7 +197,7 @@ class OpenAIRealtimeAgent(BaseAgent):
             starting_agent=self.realtime_agent,
             config=RealtimeRunConfig(
                 model_settings=RealtimeSessionModelSettings(
-                    model_name="gpt-realtime-1.5",
+                    model_name=self.model,
                     input_audio_format=self.input_audio_format,
                     output_audio_format=self.output_audio_format,
                     input_audio_transcription=RealtimeInputAudioTranscriptionConfig(

--- a/arklex/resources/agents/rule_based_agent/nlu_agent.py
+++ b/arklex/resources/agents/rule_based_agent/nlu_agent.py
@@ -59,7 +59,6 @@ class NLUAgentData(BaseModel):
 class NLUAgent(BaseAgent):
     def __init__(
         self,
-        llm_config: LLMConfig,
         nlu_graph: NLUGraph,
         executor: Executor,
         guardrail_llm_config: LLMConfig,
@@ -72,12 +71,7 @@ class NLUAgent(BaseAgent):
             self.nlu_graph.agent_node.data
         )
 
-        if self.agent_data.model:
-            update_kwargs = {"model_type_or_path": self.agent_data.model}
-            self.llm_config = llm_config.model_copy(update=update_kwargs)
-            self.nlu_graph.update_llm_config(self.llm_config)
-        else:
-            self.llm_config = llm_config
+        self.llm_config = nlu_graph.llm_config
 
     def format_system_prompt(self) -> str:
         if self.agent_data.language == "EN":

--- a/arklex/resources/agents/rule_based_agent/nlu_agent.py
+++ b/arklex/resources/agents/rule_based_agent/nlu_agent.py
@@ -52,6 +52,7 @@ class NLUAgentData(BaseModel):
     language: str
     input_guardrail_description: str | None = None
     input_guardrail_fixed_message: str | None = None
+    model: str | None = None
 
 
 @register_agent
@@ -64,13 +65,19 @@ class NLUAgent(BaseAgent):
         guardrail_llm_config: LLMConfig,
     ) -> None:
         self.user_prefix = "user"
-        self.llm_config = llm_config
         self.guardrail_llm_config = guardrail_llm_config
         self.executor = executor
         self.nlu_graph = nlu_graph
         self.agent_data: NLUAgentData = NLUAgentData.model_validate(
             self.nlu_graph.agent_node.data
         )
+
+        if self.agent_data.model:
+            update_kwargs = {"model_type_or_path": self.agent_data.model}
+            self.llm_config = llm_config.model_copy(update=update_kwargs)
+            self.nlu_graph.update_llm_config(self.llm_config)
+        else:
+            self.llm_config = llm_config
 
     def format_system_prompt(self) -> str:
         if self.agent_data.language == "EN":
@@ -144,7 +151,7 @@ class NLUAgent(BaseAgent):
         params.memory.trajectory.append([])
 
         orch_state: OrchestratorState = OrchestratorState(
-            sys_instruct=self.agent_data.prompt,
+            sys_instruct=self.format_system_prompt(),
             bot_config=BotConfig(
                 language=self.agent_data.language,
                 llm_config=self.llm_config,


### PR DESCRIPTION
## Summary
This change is to use models that the user passes in for the OpenAI Realtime, LLM Agent, and the NLU Agent. 

https://linear.app/arklex/issue/PLA-100/hub-add-model-selection-in-flow-page

## Description
Before, we hardcoded the models that we used. This change allows for the user to optionally pass in the model that they want to use. If no model is passed in, then we default to a pre-set model config (gpt-5.1 for rule-based agent and LLM Agent, gpt-realtime-1.5 for OpenAIRealtime Agent). Also fixes an issue where the max response length was being ignored for the rule-based agent. 

## Tests
- [X] Pre-commit code format check: Run `pip install pre-commit` and `pre-commit install` before committing changes
- [X] Attach one of `run-coverage-tests` label, `run-diff-coverage-tests` label, or `run-integration-tests` label (to skip test coverage) and ensure the check passes.
- [X] Test case 1: Tested OpenAI realtime, updated model. Retrieved the OpenAI API request id for the interaction to verify the model being used. Verified that the model was what I had set it to. 
- [X] Test case 2: Tested LLM Agent, updated model. Retrieved the OpenAI API request id for the interaction to verify the model being used. Verified that the model was what I had set it to. 
- [X] Test case 3: Tested NLU agent, updated model. Retrieved the OpenAI API request id for the interaction to verify the model being used. Verified that the model was what I had set it to. 

## Reviewers
@arklexai/agent-leads
