### PR TITLE
chore: add Claude Code standards, skills, and hooks

### DIFF
--- a/.claude/rules/python-style.md
+++ b/.claude/rules/python-style.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "**/*.py"
+---
+
+# Python style rules
+
+- Ruff format + ruff check enforced by hooks (auto-runs on every edit)
+- Line length: 88 (configured in pyproject.toml)
+- Lint rules: E (pycodestyle), F (pyflakes), I (isort), UP (pyupgrade), ANN (annotations), B (bugbear), SIM (simplify), C4 (comprehensions), TID (tidy-imports)
+- Ignored: E501 (line too long, handled by formatter)
+- Format: double quotes, space indent, no magic trailing comma skip, auto line endings
+- Absolute imports only
+- Type annotations on all function signatures
+- No license header required (MIT license)
+- Target version: Python 3.10

--- a/.claude/rules/python-style.md
+++ b/.claude/rules/python-style.md
@@ -10,7 +10,7 @@ paths:
 - Lint rules: E (pycodestyle), F (pyflakes), I (isort), UP (pyupgrade), ANN (annotations), B (bugbear), SIM (simplify), C4 (comprehensions), TID (tidy-imports)
 - Ignored: E501 (line too long, handled by formatter)
 - Format: double quotes, space indent, no magic trailing comma skip, auto line endings
-- Absolute imports only
+- Absolute imports preferred. Single-level relative imports (`from .module import ...`) are allowed. Multi-level relative imports (`from ..module import ...`) are not.
 - Type annotations on all function signatures
 - No license header required (MIT license)
 - Target version: Python 3.10

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "BRANCH=$(git branch --show-current 2>/dev/null); PR=$(gh pr list --head=\"$BRANCH\" --state=open --json url,title -q '.[0] | \"\\(.title) \\(.url)\"' 2>/dev/null); echo \"Branch: ${BRANCH:-detached}\"; [ -n \"$PR\" ] && echo \"Open PR: $PR\" || echo \"Open PR: none\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(jq -r '.tool_input.file_path' 2>/dev/null); [[ \"$FILE\" =~ \\.(env\\.sample|env\\.example)$ ]] && exit 0; [[ \"$FILE\" =~ \\.(env|env\\..*)$ ]] && echo 'Blocked: do not edit .env files' >&2 && exit 2; [[ \"$FILE\" =~ (secrets|credentials|keys)/ ]] && echo 'Blocked: protected directory' >&2 && exit 2; exit 0"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(jq -r '.tool_input.file_path' 2>/dev/null); [ -z \"$FILE\" ] && exit 0; if [[ \"$FILE\" == *.py ]]; then ruff format \"$FILE\" 2>/dev/null || true; ruff check --fix \"$FILE\" 2>/dev/null || true; fi; exit 0",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: draft-pr
+description: Generate a PR title and description from your changes
+disable-model-invocation: true
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Draft PR
+
+Generate a PR title and description that will pass CI checks.
+
+## Steps
+
+### 1. Gather context
+
+```bash
+git branch --show-current
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+gh pr list --head "$(git branch --show-current)" --state=open --json url -q '.[0].url'
+```
+
+### 2. Read PR template
+
+Read `.github/pull_request_template.md` for the required structure.
+
+### 3. Generate PR title
+
+- Format: `<type>(<scope>): <description>` (Conventional Commits)
+- Max 72 characters
+- Types: feat, fix, docs, chore, ci, build, refactor, test, perf, style, revert
+- Scope is optional but recommended
+
+### 4. Generate PR description
+
+Fill in each section from the template:
+
+- **Summary** (min 5 words): concise overview of what the PR does
+- **Description** (min 10 words): why the change is needed, how it works, side effects
+- **Tests** (min 10 words): describe what was tested, mention test commands run
+
+### 5. Remind about test labels
+
+The contributor must attach one of these labels after creating the PR:
+- `run-coverage-tests` - full test suite with coverage (45% minimum)
+- `run-diff-coverage-tests` - coverage on changed files only
+- `run-integration-tests` - integration tests (skips coverage gate)
+
+### 6. Output
+
+Print the generated title and full PR body in markdown, ready to copy.
+If an open PR already exists for this branch, offer to update it with `gh pr edit`.

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -48,5 +48,5 @@ The contributor must attach one of these labels after creating the PR:
 
 ### 6. Output
 
-Print the generated title and full PR body in markdown, ready to copy.
+Print the generated title and full PR body in raw markdown format, ready to copy.
 If an open PR already exists for this branch, offer to update it with `gh pr edit`.

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -39,14 +39,7 @@ Fill in each section from the template:
 - **Description** (min 10 words): why the change is needed, how it works, side effects
 - **Tests** (min 10 words): describe what was tested, mention test commands run
 
-### 5. Remind about test labels
-
-The contributor must attach one of these labels after creating the PR:
-- `run-coverage-tests` - full test suite with coverage (45% minimum)
-- `run-diff-coverage-tests` - coverage on changed files only
-- `run-integration-tests` - integration tests (skips coverage gate)
-
-### 6. Output
+### 5. Output
 
 Print the generated title and full PR body in raw markdown format, ready to copy.
 If an open PR already exists for this branch, offer to update it with `gh pr edit`.

--- a/.claude/skills/pre-review/SKILL.md
+++ b/.claude/skills/pre-review/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pre-review
+description: Check your branch before opening a PR (lint, format, tests, title)
+disable-model-invocation: true
+context: fork
+agent: Explore
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Pre-review
+
+Run local checks to catch issues before opening a PR.
+
+## Steps
+
+### 1. Check branch and changes
+
+```bash
+git branch --show-current
+git status
+git log --oneline main..HEAD
+```
+
+### 2. Run ruff linter
+
+```bash
+ruff check .
+```
+
+If there are fixable issues, run `ruff check --fix .` and report what was fixed.
+
+### 3. Run ruff formatter
+
+```bash
+ruff format --check .
+```
+
+If files would be reformatted, run `ruff format .` and report what changed.
+
+### 4. Run tests
+
+```bash
+pytest tests/ -x --tb=short
+```
+
+Report pass/fail count and any failures.
+
+### 5. Check coverage
+
+```bash
+pytest tests/ --cov=arklex --cov-fail-under=45 --cov-report=term-missing -q
+```
+
+Coverage minimum is 45%. Flag if below threshold.
+
+### 6. Validate branch name
+
+Branch should follow `<type>/<short-description>` pattern, e.g. `feat/add-retry`.
+
+### 7. Suggest PR title
+
+Based on the commits on this branch, suggest a Conventional Commits title:
+- Format: `<type>(<scope>): <description>`
+- Max 72 characters
+- Types: feat, fix, docs, chore, ci, build, refactor, test, perf, style, revert
+
+### 8. Report
+
+Summarize results:
+
+```
+Lint:     pass/fail
+Format:   pass/fail
+Tests:    X passed, Y failed
+Coverage: XX% (minimum 45%)
+Branch:   <name> (valid/invalid)
+Title:    <suggested title>
+```

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: review-pr
+description: Review a pull request against project standards
+disable-model-invocation: true
+effort: high
+argument-hint: "[PR-number]"
+context: fork
+agent: Explore
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Review PR
+
+Review a PR for code quality, conventions, and CI readiness.
+
+## Steps
+
+### 1. Load PR context
+
+```bash
+gh pr view "$1" --json title,body,files,labels,additions,deletions
+gh pr diff "$1"
+```
+
+### 2. Validate PR title
+
+Check against Conventional Commits regex (must pass CI):
+
+```
+^(feat|fix|docs|chore|ci|build|refactor|test|perf|style|revert)(\([a-z][a-z0-9_-]*\))?!?: .+$
+```
+
+- Max 72 characters
+- Common mistakes: component name as type (`orchestrator: ...`), ticket ID as type
+
+### 3. Validate PR description
+
+Check the PR body against the template in `.github/pull_request_template.md`:
+- `## Summary` section: at least 5 words of content
+- `## Description` section: at least 10 words of content
+- `## Tests` section: at least 10 words of content
+- Comments and unchecked checkboxes do not count
+
+### 4. Check test labels
+
+Verify one of these labels is present:
+- `run-coverage-tests`
+- `run-diff-coverage-tests`
+- `run-integration-tests`
+
+If missing, flag it. The PR template asks contributors to attach one.
+
+### 5. Review code changes
+
+For each changed file in `gh pr diff`:
+- **Python files**: check for type annotations, absolute imports, ruff compliance
+- **Test files**: verify new/changed code has corresponding tests
+- Coverage minimum is 45%. Flag large additions without tests.
+- No license headers needed (MIT)
+
+### 6. Check for common issues
+
+- Secrets or credentials in diff (API keys, tokens, passwords)
+- Large files or binaries that should not be committed
+- Changes to .env files (should be .env.example only)
+- Missing docstrings on public functions/classes
+
+### 7. Write review
+
+Structure the review as:
+
+```
+## Summary
+One-sentence summary of the PR.
+
+## Findings
+- List issues grouped by severity (blocking, suggestion, nit)
+
+## Checklist
+- [ ] Title matches Conventional Commits
+- [ ] Description sections meet word minimums
+- [ ] Test label attached
+- [ ] Tests cover new/changed code
+- [ ] No secrets in diff
+```
+
+Use natural sentence breaks. Do not use em dashes or en dashes.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -18,7 +18,7 @@ Review a PR for functional correctness and project conventions. Focus on logic, 
 ### 1. Load PR context
 
 ```bash
-gh pr view $ARGUMENTS --json title,body,files,labels,additions,deletions
+gh pr view $ARGUMENTS --json title,body,files,additions,deletions
 gh pr diff $ARGUMENTS
 ```
 
@@ -28,16 +28,7 @@ gh pr diff $ARGUMENTS
 - Description sections meet word minimums (Summary 5w, Description 10w, Tests 10w)
 - These are also CI-enforced, so flag only if CI somehow missed them
 
-### 3. Check test labels
-
-Verify one of these labels is present:
-- `run-coverage-tests`
-- `run-diff-coverage-tests`
-- `run-integration-tests`
-
-If missing, flag it.
-
-### 4. Review functional changes
+### 3. Review functional changes
 
 Focus on:
 - Logic correctness: does the code do what the PR claims?
@@ -68,7 +59,6 @@ One-sentence assessment.
 ## Checklist
 - [ ] Title matches Conventional Commits
 - [ ] Description sections meet word minimums
-- [ ] Test label attached
 - [ ] Functional correctness verified
 - [ ] Tests cover new/changed code
 - [ ] No secrets in diff

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -11,67 +11,56 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # Review PR
 
-Review a PR for code quality, conventions, and CI readiness.
+Review a PR for functional correctness and project conventions. Focus on logic, architecture, and behavior. Formatting issues are caught by CI (ruff, pre-commit) and do not need manual review.
 
 ## Steps
 
 ### 1. Load PR context
 
 ```bash
-gh pr view "$1" --json title,body,files,labels,additions,deletions
-gh pr diff "$1"
+gh pr view $ARGUMENTS --json title,body,files,labels,additions,deletions
+gh pr diff $ARGUMENTS
 ```
 
-### 2. Validate PR title
+### 2. Validate PR title and description
 
-Check against Conventional Commits regex (must pass CI):
+- Title matches Conventional Commits regex, under 72 chars
+- Description sections meet word minimums (Summary 5w, Description 10w, Tests 10w)
+- These are also CI-enforced, so flag only if CI somehow missed them
 
-```
-^(feat|fix|docs|chore|ci|build|refactor|test|perf|style|revert)(\([a-z][a-z0-9_-]*\))?!?: .+$
-```
-
-- Max 72 characters
-- Common mistakes: component name as type (`orchestrator: ...`), ticket ID as type
-
-### 3. Validate PR description
-
-Check the PR body against the template in `.github/pull_request_template.md`:
-- `## Summary` section: at least 5 words of content
-- `## Description` section: at least 10 words of content
-- `## Tests` section: at least 10 words of content
-- Comments and unchecked checkboxes do not count
-
-### 4. Check test labels
+### 3. Check test labels
 
 Verify one of these labels is present:
 - `run-coverage-tests`
 - `run-diff-coverage-tests`
 - `run-integration-tests`
 
-If missing, flag it. The PR template asks contributors to attach one.
+If missing, flag it.
 
-### 5. Review code changes
+### 4. Review functional changes
 
-For each changed file in `gh pr diff`:
-- **Python files**: check for type annotations, absolute imports, ruff compliance
-- **Test files**: verify new/changed code has corresponding tests
+Focus on:
+- Logic correctness: does the code do what the PR claims?
+- Edge cases: are error paths handled?
+- API changes: are they backwards compatible or properly marked as breaking?
+- Security: no hardcoded secrets, no unsanitized input in dangerous contexts
+- Performance: any obvious inefficiencies?
+
+### 5. Check scope
+
+- Single concern per PR
+- Flag unrelated changes bundled together
+
+### 6. Check test coverage
+
+- New behavior should have tests
 - Coverage minimum is 45%. Flag large additions without tests.
-- No license headers needed (MIT)
 
-### 6. Check for common issues
-
-- Secrets or credentials in diff (API keys, tokens, passwords)
-- Large files or binaries that should not be committed
-- Changes to .env files (should be .env.example only)
-- Missing docstrings on public functions/classes
-
-### 7. Write review
-
-Structure the review as:
+## Output
 
 ```
 ## Summary
-One-sentence summary of the PR.
+One-sentence assessment.
 
 ## Findings
 - List issues grouped by severity (blocking, suggestion, nit)
@@ -80,8 +69,9 @@ One-sentence summary of the PR.
 - [ ] Title matches Conventional Commits
 - [ ] Description sections meet word minimums
 - [ ] Test label attached
+- [ ] Functional correctness verified
 - [ ] Tests cover new/changed code
 - [ ] No secrets in diff
 ```
 
-Use natural sentence breaks. Do not use em dashes or en dashes.
+End with: APPROVED, CHANGES REQUESTED, or NEEDS DISCUSSION.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,41 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
+  check-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title format
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+
+            if (title.length > 72) {
+              core.setFailed(
+                `PR title is ${title.length} characters (max 72).\n` +
+                `Title: "${title}"`
+              );
+              return;
+            }
+
+            const pattern = /^(feat|fix|docs|chore|ci|build|refactor|test|perf|style|revert)(\([a-z][a-z0-9_-]*\))?!?: .+$/;
+            if (!pattern.test(title)) {
+              core.setFailed(
+                `PR title does not match the required format.\n\n` +
+                `Expected: <type>(<scope>): <description>\n` +
+                `  - type: feat, fix, docs, chore, ci, build, refactor, test, perf, style, revert\n` +
+                `  - scope (optional): lowercase, may contain digits, hyphens, underscores\n` +
+                `  - description: free text\n\n` +
+                `Common mistakes:\n` +
+                `  BAD:  orchestrator: add retry logic     (component as type)\n` +
+                `  GOOD: feat(orchestrator): add retry logic\n` +
+                `  BAD:  AGML-225: add feature             (ticket ID as type)\n` +
+                `  GOOD: feat: add feature\n\n` +
+                `Got: "${title}"`
+              );
+            }
+
   check-pr-description:
     runs-on: ubuntu-latest
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ local/*
 #####################################
 test_dir/simulate_data/*.json
 *.json.tmp
+
+# AI tool local config
+.claude/*
+!.claude/skills/
+!.claude/rules/
+!.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# Arklex - Agent-First Organization
+
+Open-source agent-first framework for building AI agents. Python 3.10+, MIT license.
+
+## Dev setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[faiss,llm]"
+pip install pre-commit && pre-commit install
+```
+
+## Code style
+
+- Formatter/linter: **Ruff** (format + check), enforced by pre-commit hooks
+- Line length: 88
+- Lint rules: E, F, I, UP, ANN, B, SIM, C4, TID (E501 ignored)
+- Format: double quotes, space indent, auto line endings
+- Absolute imports only; type annotations on all function signatures
+- No license header required (MIT)
+
+## PR conventions
+
+- **Title**: Conventional Commits format, max 72 chars
+  - `<type>(<scope>): <description>`
+  - Types: feat, fix, docs, chore, ci, build, refactor, test, perf, style, revert
+  - Scope is optional but recommended (lowercase, may contain digits/hyphens/underscores)
+  - Common mistakes: using component name as type (`orchestrator: ...`), ticket ID as type
+- **Description**: use the PR template. CI enforces minimum word counts:
+  - Summary: 5 words, Description: 10 words, Tests: 10 words
+- **Merge strategy**: squash merge
+
+## Testing
+
+```bash
+pytest tests/                          # all tests
+pytest tests/ -m "not integration"     # skip integration
+pytest tests/ -m shopify               # specific marker
+pytest tests/ --cov=arklex --cov-fail-under=45  # with coverage gate
+```
+
+- Test paths: `tests/` (subdirs: data, env, orchestrator, temp, utils)
+- Coverage minimum: **45%** (enforced in CI)
+- Markers: integration, no_intent_mock, no_llm_mock, shopify, hubspot, hitl, slow
+- Async mode: auto (pytest-asyncio)
+
+### Test labels (CI)
+
+Add one of these labels to your PR to trigger the appropriate test workflow:
+- `run-coverage-tests` - full coverage run
+- `run-diff-coverage-tests` - coverage on changed files only
+- `run-integration-tests` - integration test suite (skips coverage)
+
+## CI checks
+
+- `pr-check.yml` validates PR description sections (Summary, Description, Tests)
+- PR title validation enforces Conventional Commits format and 72-char limit
+- Coverage workflows triggered by PR labels (see above)
+
+## Pre-commit hooks
+
+Configured in `.pre-commit-config.yaml`:
+- `ruff --fix` (auto-fix lint issues)
+- `ruff-format` (auto-format)
+
+## Docs
+
+Documentation uses **Docusaurus**, located in `docs/`. Config: `docs/docusaurus.config.js`.
+
+## Writing style
+
+- Never use em dashes or en dashes in prose. Use hyphens only where grammatically needed.
+- Rephrase sentences instead of inserting dashes as punctuation.
+
+## Branch naming
+
+Use `<type>/<short-description>`, e.g. `feat/add-retry-logic`, `fix/null-pointer`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,18 +44,10 @@ pytest tests/ --cov=arklex --cov-fail-under=45  # with coverage gate
 - Markers: integration, no_intent_mock, no_llm_mock, shopify, hubspot, hitl, slow
 - Async mode: auto (pytest-asyncio)
 
-### Test labels (CI)
-
-Add one of these labels to your PR to trigger the appropriate test workflow:
-- `run-coverage-tests` - full coverage run
-- `run-diff-coverage-tests` - coverage on changed files only
-- `run-integration-tests` - integration test suite (skips coverage)
-
 ## CI checks
 
-- `pr-check.yml` validates PR description sections (Summary, Description, Tests)
-- PR title validation enforces Conventional Commits format and 72-char limit
-- Coverage workflows triggered by PR labels (see above)
+- `pr-check.yml` validates PR title (Conventional Commits, 72-char limit) and description sections (Summary, Description, Tests)
+- Coverage and integration test workflows run automatically on PRs
 
 ## Pre-commit hooks
 


### PR DESCRIPTION
## Summary

Add Claude Code standards for contributors with CLAUDE.md, skills, hooks, rules, and CI title validation.

## Description

Adds CLAUDE.md (77 lines) with project conventions including PR format, testing with 45 percent coverage and test labels, and CI checks. Adds three Claude Code skills for contributors: review-pr for reviewing PRs against standards, pre-review for self-checking before opening a PR, and draft-pr for generating PR title and description. Adds hooks for auto-format with ruff and env file protection. Adds Conventional Commits title validation to pr-check.yml with anti-pattern examples. Updates gitignore to track claude shared files.

## Tests

- [x] CLAUDE.md loads correctly (77 lines, starts with heading)
- [x] Skills appear in autocomplete (review-pr, pre-review, draft-pr)
- [x] All skill frontmatter valid (name, description, disable-model-invocation, allowed-tools, context fork, agent Explore)
- [x] No internal references in any file (Linear, Slack, private repos)
- [x] Gitignore tracks skills, rules, settings.json correctly
- [x] CI title validation job added to pr-check.yml

## Reviewers

@arklexai/agent-leads